### PR TITLE
stop fetching manifest twice

### DIFF
--- a/packages/trader/build/config.js
+++ b/packages/trader/build/config.js
@@ -6,7 +6,14 @@ const { IS_RELEASE } = require('./constants');
 const generateSWConfig = () => ({
     importWorkboxFrom: 'local',
     cleanupOutdatedCaches: true,
-    exclude: [/CNAME$/, /index\.html$/, /404\.html$/, /^public\/images\/favicons\//, /^favicon\.ico$/],
+    exclude: [
+        /CNAME$/,
+        /index\.html$/,
+        /404\.html$/,
+        /manifest\.json$/,
+        /^public\/images\/favicons\//,
+        /^favicon\.ico$/,
+    ],
     skipWaiting: true,
     clientsClaim: true,
 });


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-  stop fetching manifest twice

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
