### PR TITLE
feat: added ticks_history to calculate_marker params in contract_store

### DIFF
--- a/packages/core/src/Stores/contract-store.js
+++ b/packages/core/src/Stores/contract-store.js
@@ -74,7 +74,7 @@ export default class ContractStore extends BaseStore {
         // TODO: don't update the barriers & markers if they are not changed
         this.updateBarriersArray(contract_info, this.root_store.ui.is_dark_mode_on);
         this.markers_array = createChartMarkers(this.contract_info);
-        this.marker = calculate_marker(this.contract_info);
+        this.marker = calculate_marker(this.contract_info, this.root_store.contract_trade.ticks_history);
 
         this.contract_config = getChartConfig(this.contract_info);
         this.display_status = getDisplayStatus(this.contract_info);
@@ -213,6 +213,12 @@ export default class ContractStore extends BaseStore {
     }
 }
 
+/**
+ *
+ * @param {Object} contract_info
+ * @param {Object} ticks_history - { prices: [], times: [] } can be used to draw markers for ticks instead of teak_stream
+ * @returns {Object | null} marker object
+ */
 function calculate_marker(contract_info) {
     if (!contract_info || isMultiplierContract(contract_info.contract_type)) {
         return null;

--- a/packages/core/src/Stores/contract-trade-store.js
+++ b/packages/core/src/Stores/contract-trade-store.js
@@ -18,6 +18,7 @@ export default class ContractTradeStore extends BaseStore {
     contracts_map = {};
     @observable has_error = false;
     @observable error_message = '';
+    @observable.ref ticks_history = {};
 
     // Chart specific observables
     @observable granularity = +LocalStore.get('contract_trade.granularity') || 0;


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   investigating the possibility and feasibility of using ticks_history response instead of tick_stream array from proposal_open_contract response in order to mark every tick of Accumulators contract

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
