### PR TITLE
maryia/79085/remove_break_out_history_from_stats_widget

### DIFF
--- a/packages/components/src/components/icon/common/ic-chevron-up-normal.svg
+++ b/packages/components/src/components/icon/common/ic-chevron-up-normal.svg
@@ -1,1 +1,0 @@
-<svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.646 5.146a.5.5 0 0 1 .708 0l5.5 5.5a.5.5 0 0 1-.708.708L8 6.207l-5.146 5.147a.5.5 0 0 1-.708-.708l5.5-5.5Z" fill="var(--fill-color1)"/></svg>

--- a/packages/components/src/components/icon/icons.js
+++ b/packages/components/src/components/icon/icons.js
@@ -265,7 +265,6 @@ import './common/ic-chevron-right-bold-mt5.svg';
 import './common/ic-chevron-right-bold.svg';
 import './common/ic-chevron-right.svg';
 import './common/ic-chevron-up-bold.svg';
-import './common/ic-chevron-up-normal.svg';
 import './common/ic-chevron-up.svg';
 import './common/ic-circle-dynamic-color.svg';
 import './common/ic-circle.svg';

--- a/packages/components/stories/icon/icons.js
+++ b/packages/components/stories/icon/icons.js
@@ -147,7 +147,6 @@ export const icons =
         'IcCashierPaymentAgent',
         'IcCashierPaypalDark',
         'IcCashierPaypalLight',
-        'IcCashierPaymentAgent',
         'IcCashierPerfectMoneyDark',
         'IcCashierPerfectMoneyLight',
         'IcCashierPermatabankDark',
@@ -273,7 +272,6 @@ export const icons =
         'IcChevronRightBold',
         'IcChevronRight',
         'IcChevronUpBold',
-        'IcChevronUpNormal',
         'IcChevronUp',
         'IcCircleDynamicColor',
         'IcCircle',
@@ -881,4 +879,4 @@ export const icons =
         'IcWalletZingpayDark',
         'IcWalletZingpayLight',
     ],
-};
+}

--- a/packages/trader/src/Modules/Contract/Components/AccumulatorsStats/__tests__/accumulators-stats.spec.js
+++ b/packages/trader/src/Modules/Contract/Components/AccumulatorsStats/__tests__/accumulators-stats.spec.js
@@ -1,21 +1,12 @@
 import React from 'react';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import { isDesktop, isMobile } from '@deriv/shared';
-import AccumulatorsStats, { CONTRACT_TYPES, ROW_SIZES } from '../accumulators-stats';
+import AccumulatorsStats, { ROW_SIZES } from '../accumulators-stats';
 
 const mock_connect_props = {
     ticks_history_stats: {
-        ACCU: {
-            ticks_stayed_in: [1, 65, 1234, 675, 234, 10, 658, 134, 5, 2394, 100, 6, 90, 9, 344, 81, 695, 14, 345, 2222],
-            last_tick_epoch: 1005,
-        },
-        DECCU: {
-            ticks_stayed_in: [
-                131, 2853, 423, 33, 1573, 1312, 23, 4213, 323, 573, 1313, 223, 4238, 373, 193, 1317, 2883, 403, 303,
-                7777,
-            ],
-            last_tick_epoch: 1010,
-        },
+        ticks_stayed_in: [1, 65, 1234, 675, 234, 10, 658, 134, 5, 2394, 100, 6, 90, 9, 344, 81, 695, 14, 345, 2222],
+        last_tick_epoch: 1005,
     },
 };
 
@@ -35,8 +26,7 @@ describe('AccumulatorsStats', () => {
     const modal_root_el = document.createElement('div');
     modal_root_el.setAttribute('id', 'modal_root');
     document.body.appendChild(modal_root_el);
-    const stay_in_history = mock_connect_props.ticks_history_stats.ACCU.ticks_stayed_in;
-    const break_out_history = mock_connect_props.ticks_history_stats.DECCU.ticks_stayed_in;
+    const ticks_history = mock_connect_props.ticks_history_stats.ticks_stayed_in;
 
     beforeEach(() => {
         isMobile.mockReturnValue(false);
@@ -50,29 +40,6 @@ describe('AccumulatorsStats', () => {
     it('should render as non-expandable', () => {
         const { container } = render(<AccumulatorsStats is_expandable={false} />);
         expect(container.querySelector('.accordion-toggle-arrow')).not.toBeInTheDocument();
-    });
-    it('should switch to Break out history when switcher are clicked and back to Stay in history when clicked again', () => {
-        render(<AccumulatorsStats />);
-        expect(screen.getByText(`${CONTRACT_TYPES.STAY_IN} history`)).toBeInTheDocument();
-        expect(screen.getByText(stay_in_history[0])).toBeInTheDocument();
-
-        fireEvent.click(screen.getByTestId('dt_accu_stats_switcher'));
-        expect(screen.getByText(`${CONTRACT_TYPES.BREAK_OUT} history`)).toBeInTheDocument();
-        expect(screen.getByText(break_out_history[0])).toBeInTheDocument();
-
-        fireEvent.click(screen.getByTestId('dt_accu_stats_switcher'));
-        expect(screen.getByText(`${CONTRACT_TYPES.STAY_IN} history`)).toBeInTheDocument();
-        expect(screen.getByText(stay_in_history[0])).toBeInTheDocument();
-    });
-    it('should not switch to Break out history when DECCU history is missing', () => {
-        mock_connect_props.ticks_history_stats.DECCU = {};
-        render(<AccumulatorsStats />);
-        expect(screen.getByText(`${CONTRACT_TYPES.STAY_IN} history`)).toBeInTheDocument();
-        expect(screen.getByText(stay_in_history[0])).toBeInTheDocument();
-
-        fireEvent.click(screen.getByTestId('dt_accu_stats_switcher'));
-        expect(screen.queryByText(`${CONTRACT_TYPES.BREAK_OUT} history`)).not.toBeInTheDocument();
-        expect(screen.getByText(`${CONTRACT_TYPES.STAY_IN} history`)).toBeInTheDocument();
     });
     it('should show manual after info icon is clicked', () => {
         const { container } = render(<AccumulatorsStats />);

--- a/packages/trader/src/Modules/Contract/Components/AccumulatorsStats/accumulators-stats.jsx
+++ b/packages/trader/src/Modules/Contract/Components/AccumulatorsStats/accumulators-stats.jsx
@@ -9,10 +9,6 @@ import TicksHistoryCounter from './ticks-history-counter';
 import { AccumulatorsStatsManualModal } from './accumulators-stats-manual-modal';
 import 'Sass/app/modules/contract/accumulators-stats.scss';
 
-export const CONTRACT_TYPES = {
-    STAY_IN: 'Stay in',
-    BREAK_OUT: 'Break out',
-};
 export const ROW_SIZES = {
     DESKTOP_COLLAPSED: 10,
     DESKTOP_EXPANDED: 10,
@@ -23,11 +19,8 @@ export const ROW_SIZES = {
 const AccumulatorsStats = ({ is_expandable = true, ticks_history_stats = {} }) => {
     const [is_collapsed, setIsCollapsed] = React.useState(true);
     const [is_manual_open, setIsManualOpen] = React.useState(false);
-    const [displayed_contract_name, setDisplayedContractName] = React.useState(CONTRACT_TYPES.STAY_IN);
-    const { ACCU, DECCU } = ticks_history_stats;
-    const widget_title = localize('{{displayed_contract_name}} history', { displayed_contract_name });
-    const ticks_history =
-        (displayed_contract_name === CONTRACT_TYPES.STAY_IN ? ACCU?.ticks_stayed_in : DECCU?.ticks_stayed_in) || [];
+    const widget_title = localize('Stay in history');
+    const ticks_history = ticks_history_stats?.ticks_stayed_in || [];
     const history_text_size = isDesktop() || !is_collapsed ? 'xxs' : 'xxxs';
 
     const rows = ticks_history.reduce((acc, _el, index) => {
@@ -39,12 +32,6 @@ const AccumulatorsStats = ({ is_expandable = true, ticks_history_stats = {} }) =
         }
         return acc;
     }, []);
-
-    const handleSwitchBetweenContracts = () => {
-        // don't switch if ACCU or DECCU history is missing
-        if (!ACCU?.ticks_stayed_in?.length || !DECCU?.ticks_stayed_in?.length) return;
-        setDisplayedContractName(Object.values(CONTRACT_TYPES).find(name => name !== displayed_contract_name));
-    };
 
     const DynamicWrapper = {
         Component: isMobile() ? MobileDialog : React.Fragment,
@@ -74,15 +61,6 @@ const AccumulatorsStats = ({ is_expandable = true, ticks_history_stats = {} }) =
                     <Text weight='bold' size={isMobile() ? 'xxxs' : 'xxs'} className='accumulators-stats__title-text'>
                         {widget_title}
                     </Text>
-                    <div
-                        data-testid='dt_accu_stats_switcher'
-                        className='accumulators-stats__switcher'
-                        onClick={handleSwitchBetweenContracts}
-                    >
-                        {['IcChevronUpNormal', 'IcChevronDown'].map(icon => (
-                            <Icon key={icon} icon={icon} />
-                        ))}
-                    </div>
                 </div>
                 <Text size={history_text_size} className='accumulators-stats__history'>
                     {!is_collapsed ? (

--- a/packages/trader/src/Modules/Trading/Components/Elements/__tests__/purchase-buttons-overlay.spec.js
+++ b/packages/trader/src/Modules/Trading/Components/Elements/__tests__/purchase-buttons-overlay.spec.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { expect } from 'chai';
+import { configure, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import PurchaseButtonsOverlay from '../purchase-buttons-overlay.jsx';
+
+configure({ adapter: new Adapter() });
+
+describe('PurchaseButtonsOverlay', () => {
+    const message = 'You can only purchase one contract at a time';
+
+    it('should render <PurchaseButtonsOverlay /> component', () => {
+        const wrapper = mount(<PurchaseButtonsOverlay message={message} />);
+        const has_correct_message = wrapper.contains(message);
+        expect(has_correct_message).to.equal(true);
+    });
+
+    it('should have purchase-buttons-overlay__one-button class when is_to_cover_one_button prop is passed', () => {
+        const wrapper = mount(<PurchaseButtonsOverlay message={message} is_to_cover_one_button />);
+        expect(wrapper.render()[0].attribs.class).to.match(/__one-button/);
+    });
+});

--- a/packages/trader/src/Modules/Trading/Components/Elements/purchase-buttons-overlay.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Elements/purchase-buttons-overlay.jsx
@@ -7,14 +7,14 @@ const PurchaseButtonsOverlay = ({ is_to_cover_one_button = false, message }) => 
     const desktop_text_size = is_to_cover_one_button ? 'xxs' : 'xs';
     return (
         <div
-            className={classNames('contract-limit-overlay', {
-                'contract-limit-overlay__one-button': !isMobile() && is_to_cover_one_button,
+            className={classNames('purchase-buttons-overlay', {
+                'purchase-buttons-overlay__one-button': !isMobile() && is_to_cover_one_button,
             })}
         >
             <Text
                 weight='bold'
                 size={isMobile() ? 'xxs' : desktop_text_size}
-                className='contract-limit-overlay__caption'
+                className='purchase-buttons-overlay__caption'
             >
                 {message}
             </Text>

--- a/packages/trader/src/Modules/Trading/Containers/purchase.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/purchase.jsx
@@ -91,7 +91,11 @@ const Purchase = ({
     });
     if (is_accumulator && last_contract_status === 'open') {
         components.unshift(
-            <PurchaseButtonsOverlay key='overlay' message={localize('You can only purchase one contract at a time')} />
+            <PurchaseButtonsOverlay
+                is_to_cover_one_button={components.length === 1}
+                key='overlay'
+                message={localize('You can only purchase one contract at a time')}
+            />
         );
     }
     return components;

--- a/packages/trader/src/Stores/Modules/Trading/Helpers/__tests__/accumulator.js
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/__tests__/accumulator.js
@@ -3,137 +3,93 @@ import { getUpdatedTicksHistoryStats } from '../accumulator';
 
 describe('getUpdatedTicksHistoryStats', () => {
     const existing_ticks_history_stats = {
-        ACCU: {
-            ticks_stayed_in: [1, 65, 1234, 675, 234],
-            last_tick_epoch: 1005,
-        },
-        DECCU: {
-            ticks_stayed_in: [131, 2853, 423, 33, 1573],
-            last_tick_epoch: 1010,
-        },
+        ticks_stayed_in: [1, 65, 1234, 675, 234],
+        last_tick_epoch: 1005,
     };
-    const new_ticks_stayed_in = [1573, 33, 423, 2853, 131];
-    const new_tick_epoch_accu = 1006;
+    const new_ticks_history_stats = [1573, 33, 423, 2853, 131];
+    const new_tick_epoch = 1006;
 
     const current_counter_same_value = { counter_value: 1, epoch: 1005 };
     const current_counter_new_value = { counter_value: 2, epoch: 1006 };
     const next_counter_initial_value = { counter_value: 0, epoch: 1006 };
     const next_counter_latest_value = { counter_value: 1, epoch: 1007 };
 
-    it('returns a ticks_history_stats with reversed ticks_stayed_in for specific contract_type when new_ticks_stayed_in.length > 1', () => {
-        const expected_ticks_history_stats = {
-            ACCU: {
-                ticks_stayed_in: [131, 2853, 423, 33, 1573],
-                last_tick_epoch: 1006,
-            },
-            DECCU: {
-                ticks_stayed_in: [131, 2853, 423, 33, 1573],
-                last_tick_epoch: 1010,
-            },
-        };
+    it('returns a ticks_history_stats with reversed ticks_stayed_in when new_ticks_history_stats.length > 1', () => {
+        const expected_ticks_history_stats = { ticks_stayed_in: [131, 2853, 423, 33, 1573], last_tick_epoch: 1006 };
         expect(
             getUpdatedTicksHistoryStats({
-                contract_type: 'ACCU',
                 previous_ticks_history_stats: {},
-                new_ticks_stayed_in,
-                last_tick_epoch: new_tick_epoch_accu,
+                new_ticks_history_stats,
+                last_tick_epoch: new_tick_epoch,
             })
-        ).to.eql({ ACCU: expected_ticks_history_stats.ACCU });
+        ).to.eql(expected_ticks_history_stats);
         const new_ticks_history = getUpdatedTicksHistoryStats({
-            contract_type: 'ACCU',
             previous_ticks_history_stats: existing_ticks_history_stats,
-            new_ticks_stayed_in,
-            last_tick_epoch: new_tick_epoch_accu,
+            new_ticks_history_stats,
+            last_tick_epoch: new_tick_epoch,
         });
         expect(new_ticks_history).to.eql(expected_ticks_history_stats);
         expect(new_ticks_history).to.not.eql(existing_ticks_history_stats);
     });
 
-    it('returns the same ticks_history_stats when new_ticks_stayed_in is undefined', () => {
+    it('returns the same ticks_history_stats when new_ticks_history_stats is undefined', () => {
         expect(
             getUpdatedTicksHistoryStats({
-                contract_type: 'ACCU',
                 previous_ticks_history_stats: existing_ticks_history_stats,
-                last_tick_epoch: new_tick_epoch_accu,
+                last_tick_epoch: new_tick_epoch,
             })
         ).to.eql(existing_ticks_history_stats);
     });
 
-    it('returns the same ticks_history_stats when new_ticks_stayed_in contains the same single value of the current counter', () => {
+    it('returns the same ticks_history_stats when new_ticks_history_stats contains the same single value of the current counter', () => {
         expect(
             getUpdatedTicksHistoryStats({
-                contract_type: 'ACCU',
                 previous_ticks_history_stats: existing_ticks_history_stats,
-                new_ticks_stayed_in: [current_counter_same_value.counter_value],
+                new_ticks_history_stats: [current_counter_same_value.counter_value],
                 last_tick_epoch: current_counter_same_value.epoch,
             })
         ).to.eql(existing_ticks_history_stats);
     });
 
-    it('returns a new ticks_history_stats with 1st item in ticks_stayed_in for specific contract type replaced with a current counter new value', () => {
+    it('returns a new ticks_history_stats with 1st item in ticks_stayed_in replaced with a current counter new value', () => {
         const expected_ticks_history_stats = {
-            ACCU: {
-                ticks_stayed_in: [2, 65, 1234, 675, 234],
-                last_tick_epoch: 1006,
-            },
-            DECCU: {
-                ticks_stayed_in: [131, 2853, 423, 33, 1573],
-                last_tick_epoch: 1010,
-            },
+            ticks_stayed_in: [2, 65, 1234, 675, 234],
+            last_tick_epoch: 1006,
         };
         expect(
             getUpdatedTicksHistoryStats({
-                contract_type: 'ACCU',
                 previous_ticks_history_stats: existing_ticks_history_stats,
-                new_ticks_stayed_in: [current_counter_new_value.counter_value],
+                new_ticks_history_stats: [current_counter_new_value.counter_value],
                 last_tick_epoch: current_counter_new_value.epoch,
             })
         ).to.eql(expected_ticks_history_stats);
     });
 
-    it('returns a new ticks_history_stats with a shifted ticks_stayed_in array of the same length & with new_ticks_stayed_in[0] placed as 1st item when its a counter_value < previous counter_value & an epoch > a previous epoch', () => {
+    it('returns a new ticks_history_stats with a shifted ticks_stayed_in array of the same length & with new_ticks_history_stats[0] placed as 1st item when its a counter_value < previous counter_value & an epoch > a previous epoch', () => {
         const expected_ticks_history_stats = {
-            ACCU: {
-                ticks_stayed_in: [0, 1, 65, 1234, 675],
-                last_tick_epoch: 1006,
-            },
-            DECCU: {
-                ticks_stayed_in: [131, 2853, 423, 33, 1573],
-                last_tick_epoch: 1010,
-            },
+            ticks_stayed_in: [0, 1, 65, 1234, 675],
+            last_tick_epoch: 1006,
         };
         const new_ticks_history = getUpdatedTicksHistoryStats({
-            contract_type: 'ACCU',
             previous_ticks_history_stats: existing_ticks_history_stats,
-            new_ticks_stayed_in: [next_counter_initial_value.counter_value],
+            new_ticks_history_stats: [next_counter_initial_value.counter_value],
             last_tick_epoch: next_counter_initial_value.epoch,
         });
         expect(new_ticks_history).to.eql(expected_ticks_history_stats);
-        expect(new_ticks_history.ACCU.ticks_stayed_in).to.have.lengthOf(
-            existing_ticks_history_stats.ACCU.ticks_stayed_in.length
-        );
+        expect(new_ticks_history.ticks_stayed_in).to.have.lengthOf(existing_ticks_history_stats.ticks_stayed_in.length);
     });
 
-    it('returns a new ticks_history_stats with a shifted ticks_stayed_in array of the same length & with new_ticks_stayed_in[0] placed as 1st item when counter value === previous counter_value & an epoch > previous epoch', () => {
+    it('returns a new ticks_history_stats with a shifted ticks_stayed_in array of the same length & with new_ticks_history_stats[0] placed as 1st item when counter value === previous counter_value & an epoch > previous epoch', () => {
         const expected_ticks_history_stats = {
-            ACCU: {
-                ticks_stayed_in: [1, 1, 65, 1234, 675],
-                last_tick_epoch: 1007,
-            },
-            DECCU: {
-                ticks_stayed_in: [131, 2853, 423, 33, 1573],
-                last_tick_epoch: 1010,
-            },
+            ticks_stayed_in: [1, 1, 65, 1234, 675],
+            last_tick_epoch: 1007,
         };
         const new_ticks_history = getUpdatedTicksHistoryStats({
-            contract_type: 'ACCU',
             previous_ticks_history_stats: existing_ticks_history_stats,
-            new_ticks_stayed_in: [next_counter_latest_value.counter_value],
+            new_ticks_history_stats: [next_counter_latest_value.counter_value],
             last_tick_epoch: next_counter_latest_value.epoch,
         });
         expect(new_ticks_history).to.eql(expected_ticks_history_stats);
-        expect(new_ticks_history.ACCU.ticks_stayed_in).to.have.lengthOf(
-            existing_ticks_history_stats.ACCU.ticks_stayed_in.length
-        );
+        expect(new_ticks_history.ticks_stayed_in).to.have.lengthOf(existing_ticks_history_stats.ticks_stayed_in.length);
     });
 });

--- a/packages/trader/src/Stores/Modules/Trading/Helpers/accumulator.js
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/accumulator.js
@@ -1,33 +1,28 @@
 /**
- *
- * @param {string} contract_type - contract type: 'ACCU' or 'DECCU';
- * @param {Object} previous_ticks_history_stats - an array of type: {
- *                              ACCU: { ticks_stayed_in: number[], last_tick_epoch: number },
- *                              DECCU: { ticks_stayed_in: [], last_tick_epoch: 1624223234 }
- *                            } with ticks_stayed_in starting with the latest counter value;
- * @param {number[]} new_ticks_stayed_in - an array of ticks counters containing 100 last values at first, and then only 1 latest updated counter value;
+ * @param {Object} previous_ticks_history_stats - an object of type: { ticks_stayed_in: number[], last_tick_epoch: number }
+ *                                                with ticks_stayed_in starting with the latest counter value;
+ * @param {number[]} new_ticks_history_stats - an array of ticks counters containing 100 last values at first, and then only 1 latest updated counter value;
  * @param {number} last_tick_epoch - an epoch of the latest tick counted by the latest (last) ticks counter in new_ticks_stayed_in array;
- * @returns an array of the same type as previous_ticks_history_stats.
+ * @returns an object of the same type as previous_ticks_history_stats.
  */
 export const getUpdatedTicksHistoryStats = ({
-    contract_type = '',
     previous_ticks_history_stats = {},
-    new_ticks_stayed_in = [],
+    new_ticks_history_stats = [],
     last_tick_epoch,
 }) => {
     // we anticipate that the latest counter value will be the last one in the received new_ticks_stayed_in array:
     let ticks_stayed_in = [];
-    const previous_history = previous_ticks_history_stats[contract_type]?.ticks_stayed_in || [];
-    const previous_epoch = previous_ticks_history_stats[contract_type]?.last_tick_epoch;
-    if (!new_ticks_stayed_in.length || !last_tick_epoch) return previous_ticks_history_stats;
-    if (new_ticks_stayed_in.length > 1) {
-        ticks_stayed_in = [...new_ticks_stayed_in].reverse();
-    } else if (new_ticks_stayed_in[0] <= previous_history[0] && last_tick_epoch > previous_epoch) {
-        ticks_stayed_in = [new_ticks_stayed_in[0], ...previous_history.slice(0, previous_history.length - 1)];
+    const previous_history = previous_ticks_history_stats.ticks_stayed_in || [];
+    const previous_epoch = previous_ticks_history_stats.last_tick_epoch;
+    if (!new_ticks_history_stats.length || !last_tick_epoch) return previous_ticks_history_stats;
+    if (new_ticks_history_stats.length > 1) {
+        ticks_stayed_in = [...new_ticks_history_stats].reverse();
+    } else if (new_ticks_history_stats[0] <= previous_history[0] && last_tick_epoch > previous_epoch) {
+        ticks_stayed_in = [new_ticks_history_stats[0], ...previous_history.slice(0, previous_history.length - 1)];
     } else if (last_tick_epoch === previous_epoch) {
         ticks_stayed_in = previous_history;
     } else {
-        ticks_stayed_in = [new_ticks_stayed_in[0], ...previous_history.slice(1)];
+        ticks_stayed_in = [new_ticks_history_stats[0], ...previous_history.slice(1)];
     }
-    return { ...previous_ticks_history_stats, [contract_type]: { ticks_stayed_in, last_tick_epoch } };
+    return { ticks_stayed_in, last_tick_epoch };
 };

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.js
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.js
@@ -986,16 +986,10 @@ export default class TradeStore extends BaseStore {
                 this.proposal_info.DECCU;
             this.root_store.contract_trade.current_spot_time = spot_time;
             this.ticks_history_stats = getUpdatedTicksHistoryStats({
-                contract_type,
                 previous_ticks_history_stats: this.ticks_history_stats,
-                new_ticks_stayed_in: contract_type === 'ACCU' ? stay_in_history : break_out_history,
-                last_tick_epoch: contract_type === 'ACCU' ? last_tick_epoch_accu : last_tick_epoch_deccu,
-            });
-            // TODO: maryia - remove, temporary value:
-            this.ticks_history_stats = {
-                ...this.ticks_history_stats,
-                DECCU: { ticks_stayed_in: break_out_history, last_tick_epoch: last_tick_epoch_deccu },
-            };
+                new_ticks_history_stats: stay_in_history.length ? stay_in_history : break_out_history,
+                last_tick_epoch: stay_in_history.length ? last_tick_epoch_accu : last_tick_epoch_deccu,
+            }); // in case ticks history is missing in ACCU response, we'll fall back to the same one from DECCU
             this.tick_size_barrier = tick_size_barrier;
             this.maximum_ticks = maximum_ticks;
             this.maximum_payout = maximum_payout;

--- a/packages/trader/src/sass/app/modules/contract/accumulators-stats.scss
+++ b/packages/trader/src/sass/app/modules/contract/accumulators-stats.scss
@@ -49,11 +49,10 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        width: 11.9rem;
+        width: 8.7rem;
 
         @include mobile {
             width: unset;
-            min-width: 9.8rem;
             flex-shrink: 1;
         }
         &-text {
@@ -68,11 +67,6 @@
                 opacity: 1;
             }
         }
-    }
-    &__switcher {
-        display: flex;
-        flex-direction: column;
-        cursor: pointer;
     }
     &__history {
         display: flex;

--- a/packages/trader/src/sass/app/modules/trading.scss
+++ b/packages/trader/src/sass/app/modules/trading.scss
@@ -602,7 +602,7 @@
         }
     }
 
-    .contract-limit-overlay {
+    .purchase-buttons-overlay {
         position: absolute;
         top: 0;
         left: 0;


### PR DESCRIPTION
## Changes:

Please include a summary of the change and which issue is fixed below:
-   to remove break out history from stats widget

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [ ] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
