### PR TITLE
Kate/87536/add existing Duration & Amount(Stake) components to Turbos Trade params

### DIFF
--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Turbos/turbos-info.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Turbos/turbos-info.jsx
@@ -5,27 +5,27 @@ import { Money, Text } from '@deriv/components';
 import { Localize } from '@deriv/translations';
 import { connect } from 'Stores/connect';
 
-const TurbosInfo = ({ className, currency, has_stop_loss, max_stake = 100, min_stake = 1 }) => {
-    const getTextForStake = (text, amount_of_stake) => (
-        <Text
-            as='p'
-            line_height='s'
-            size='xxxs'
-            className={classNames({
-                [`${className}-tooltip-text`]: className,
-            })}
-        >
-            <Localize
-                i18n_default_text={text}
-                components={[<Money key={0} amount={amount_of_stake} currency={currency} show_currency />]}
-            />
-        </Text>
-    );
+const getTextForStake = (amount_of_stake, className, currency, text) => (
+    <Text
+        as='p'
+        line_height='s'
+        size='xxxs'
+        className={classNames({
+            [`${className}-tooltip-text`]: className,
+        })}
+    >
+        <Localize
+            i18n_default_text={text}
+            components={[<Money key={0} amount={amount_of_stake} currency={currency} show_currency />]}
+        />
+    </Text>
+);
 
+const TurbosInfo = ({ className, currency, has_stop_loss, max_stake, min_stake }) => {
     return (
         <div className={classNames('turbos-trade-info', className)}>
-            {getTextForStake('Min. stake <0/>', min_stake)}
-            {!has_stop_loss && getTextForStake('Max. stake <0/>', max_stake)}
+            {getTextForStake(min_stake, className, currency, 'Min. stake <0/>')}
+            {!has_stop_loss && getTextForStake(max_stake, className, currency, 'Max. stake <0/>')}
         </div>
     );
 };

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Turbos/turbos-info.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Turbos/turbos-info.jsx
@@ -5,8 +5,8 @@ import { Money, Text } from '@deriv/components';
 import { Localize } from '@deriv/translations';
 import { connect } from 'Stores/connect';
 
-const TurbosInfo = ({ min_stack = 1, className, currency, has_stop_loss, max_stack = 100 }) => {
-    const min_stake_text = (
+const TurbosInfo = ({ className, currency, has_stop_loss, max_stake = 100, min_stake = 1 }) => {
+    const getTextForStake = (text, amount_of_stake) => (
         <Text
             as='p'
             line_height='s'
@@ -16,32 +16,16 @@ const TurbosInfo = ({ min_stack = 1, className, currency, has_stop_loss, max_sta
             })}
         >
             <Localize
-                i18n_default_text='Min. stake <0/>'
-                components={[<Money key={0} amount={min_stack} currency={currency} show_currency />]}
-            />
-        </Text>
-    );
-
-    const max_stake_text = (
-        <Text
-            as='p'
-            line_height='s'
-            size='xxxs'
-            className={classNames({
-                [`${className}-tooltip-text`]: className,
-            })}
-        >
-            <Localize
-                i18n_default_text='Max. stake <0/>'
-                components={[<Money key={0} amount={max_stack} currency={currency} show_currency />]}
+                i18n_default_text={text}
+                components={[<Money key={0} amount={amount_of_stake} currency={currency} show_currency />]}
             />
         </Text>
     );
 
     return (
         <div className={classNames('turbos-trade-info', className)}>
-            {min_stake_text}
-            {!has_stop_loss && max_stake_text}
+            {getTextForStake('Min. stake <0/>', min_stake)}
+            {!has_stop_loss && getTextForStake('Max. stake <0/>', max_stake)}
         </div>
     );
 };
@@ -51,14 +35,14 @@ TurbosInfo.propTypes = {
     className: PropTypes.string,
     currency: PropTypes.string,
     has_stop_loss: PropTypes.bool,
-    max_stack: PropTypes.number,
-    min_stack: PropTypes.number,
+    max_stake: PropTypes.number,
+    min_stake: PropTypes.number,
 };
 
 export default connect(({ modules }, props) => ({
     amount: props.amount ?? modules.trade.amount,
     currency: modules.trade.currency,
     has_stop_loss: modules.trade.has_stop_loss,
-    max_stack: props.max_stack ?? modules.trade.max_stack,
-    min_stack: props.min_stack ?? modules.trade.min_stack,
+    max_stake: props.max_stake ?? modules.trade.max_stake,
+    min_stake: props.min_stake ?? modules.trade.min_stake,
 }))(TurbosInfo);

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Turbos/turbos-info.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Turbos/turbos-info.jsx
@@ -1,0 +1,64 @@
+import classNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Money, Text } from '@deriv/components';
+import { Localize } from '@deriv/translations';
+import { connect } from 'Stores/connect';
+
+const TurbosInfo = ({ min_stack = 1, className, currency, has_stop_loss, max_stack = 100 }) => {
+    const min_stake_text = (
+        <Text
+            as='p'
+            line_height='s'
+            size='xxxs'
+            className={classNames({
+                [`${className}-tooltip-text`]: className,
+            })}
+        >
+            <Localize
+                i18n_default_text='Min. stake <0/>'
+                components={[<Money key={0} amount={min_stack} currency={currency} show_currency />]}
+            />
+        </Text>
+    );
+
+    const max_stake_text = (
+        <Text
+            as='p'
+            line_height='s'
+            size='xxxs'
+            className={classNames({
+                [`${className}-tooltip-text`]: className,
+            })}
+        >
+            <Localize
+                i18n_default_text='Max. stake <0/>'
+                components={[<Money key={0} amount={max_stack} currency={currency} show_currency />]}
+            />
+        </Text>
+    );
+
+    return (
+        <div className={classNames('turbos-trade-info', className)}>
+            {min_stake_text}
+            {!has_stop_loss && max_stake_text}
+        </div>
+    );
+};
+
+TurbosInfo.propTypes = {
+    amount: PropTypes.number,
+    className: PropTypes.string,
+    currency: PropTypes.string,
+    has_stop_loss: PropTypes.bool,
+    max_stack: PropTypes.number,
+    min_stack: PropTypes.number,
+};
+
+export default connect(({ modules }, props) => ({
+    amount: props.amount ?? modules.trade.amount,
+    currency: modules.trade.currency,
+    has_stop_loss: modules.trade.has_stop_loss,
+    max_stack: props.max_stack ?? modules.trade.max_stack,
+    min_stack: props.min_stack ?? modules.trade.min_stack,
+}))(TurbosInfo);

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Turbos/turbos-info.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/Turbos/turbos-info.jsx
@@ -5,7 +5,7 @@ import { Money, Text } from '@deriv/components';
 import { Localize } from '@deriv/translations';
 import { connect } from 'Stores/connect';
 
-const getTextForStake = (amount_of_stake, className, currency, text) => (
+const StakeText = ({ amount_of_stake, className, currency, text }) => (
     <Text
         as='p'
         line_height='s'
@@ -24,8 +24,15 @@ const getTextForStake = (amount_of_stake, className, currency, text) => (
 const TurbosInfo = ({ className, currency, has_stop_loss, max_stake, min_stake }) => {
     return (
         <div className={classNames('turbos-trade-info', className)}>
-            {getTextForStake(min_stake, className, currency, 'Min. stake <0/>')}
-            {!has_stop_loss && getTextForStake(max_stake, className, currency, 'Max. stake <0/>')}
+            <StakeText amount_of_stake={min_stake} className={className} currency={currency} text={'Min. stake <0/>'} />
+            {!has_stop_loss && (
+                <StakeText
+                    amount_of_stake={max_stake}
+                    className={className}
+                    currency={currency}
+                    text={'Max. stake <0/>'}
+                />
+            )}
         </div>
     );
 };
@@ -39,10 +46,10 @@ TurbosInfo.propTypes = {
     min_stake: PropTypes.number,
 };
 
-export default connect(({ modules }, props) => ({
-    amount: props.amount ?? modules.trade.amount,
+export default connect(({ modules }) => ({
+    amount: modules.trade.amount,
     currency: modules.trade.currency,
     has_stop_loss: modules.trade.has_stop_loss,
-    max_stake: props.max_stake ?? modules.trade.max_stake,
-    min_stake: props.min_stake ?? modules.trade.min_stake,
+    max_stake: modules.trade.max_stake,
+    min_stake: modules.trade.min_stake,
 }))(TurbosInfo);

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.jsx
@@ -2,25 +2,27 @@ import React from 'react';
 import { Tabs, Money, Numpad } from '@deriv/components';
 import { isEmptyObject, getDecimalPlaces } from '@deriv/shared';
 import { Localize, localize } from '@deriv/translations';
+import TurbosInfo from './Turbos/turbos-info.jsx';
 
 import { connect } from 'Stores/connect';
 
 const Basis = ({
     addToast,
+    basis,
+    currency,
     duration_unit,
     duration_value,
-    toggleModal,
-    basis,
     has_duration_error,
+    is_turbos,
+    onChangeMultiple,
     selected_basis,
     setSelectedAmount,
-    onChangeMultiple,
-    currency,
+    setAmountError,
     trade_amount,
     trade_basis,
     trade_duration,
     trade_duration_unit,
-    setAmountError,
+    toggleModal,
 }) => {
     const user_currency_decimal_places = getDecimalPlaces(currency);
     const onNumberChange = num => {
@@ -65,40 +67,48 @@ const Basis = ({
     };
 
     return (
-        <div className='trade-params__amount-keypad'>
-            <Numpad
-                value={selected_basis}
-                format={formatAmount}
-                onSubmit={setBasisAndAmount}
-                currency={currency}
-                min={min_amount}
-                is_currency
-                render={({ value: v, className }) => {
-                    return (
-                        <div className={className}>
-                            {parseFloat(v) > 0 ? <Money currency={currency} amount={v} should_format={false} /> : v}
-                        </div>
-                    );
-                }}
-                reset_press_interval={450}
-                reset_value=''
-                pip_size={user_currency_decimal_places}
-                onValidate={validateAmount}
-                submit_label={localize('OK')}
-                onValueChange={onNumberChange}
-            />
-        </div>
+        <React.Fragment>
+            {is_turbos && (
+                <div className='trade-params__stake-container'>
+                    <TurbosInfo className='trade-container__turbos-trade-info' />
+                </div>
+            )}
+            <div className='trade-params__amount-keypad'>
+                <Numpad
+                    value={selected_basis}
+                    format={formatAmount}
+                    onSubmit={setBasisAndAmount}
+                    currency={currency}
+                    min={min_amount}
+                    is_currency
+                    render={({ value: v, className }) => {
+                        return (
+                            <div className={className}>
+                                {parseFloat(v) > 0 ? <Money currency={currency} amount={v} should_format={false} /> : v}
+                            </div>
+                        );
+                    }}
+                    reset_press_interval={450}
+                    reset_value=''
+                    pip_size={user_currency_decimal_places}
+                    onValidate={validateAmount}
+                    submit_label={localize('OK')}
+                    onValueChange={onNumberChange}
+                />
+            </div>
+        </React.Fragment>
     );
 };
 
 const AmountWrapper = connect(({ modules, client, ui }) => ({
+    addToast: ui.addToast,
+    currency: client.currency,
+    is_turbos: modules.trade.is_turbos,
     onChangeMultiple: modules.trade.onChangeMultiple,
     trade_amount: modules.trade.amount,
     trade_basis: modules.trade.basis,
     trade_duration_unit: modules.trade.duration_unit,
     trade_duration: modules.trade.duration,
-    currency: client.currency,
-    addToast: ui.addToast,
 }))(Basis);
 
 const Amount = ({

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount-mobile.jsx
@@ -81,10 +81,14 @@ const Basis = ({
                     currency={currency}
                     min={min_amount}
                     is_currency
-                    render={({ value: v, className }) => {
+                    render={({ value, className }) => {
                         return (
                             <div className={className}>
-                                {parseFloat(v) > 0 ? <Money currency={currency} amount={v} should_format={false} /> : v}
+                                {parseFloat(value) > 0 ? (
+                                    <Money currency={currency} amount={value} should_format={false} />
+                                ) : (
+                                    value
+                                )}
                             </div>
                         );
                     }}

--- a/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/TradeParams/amount.jsx
@@ -10,6 +10,7 @@ import { Localize, localize } from '@deriv/translations';
 import AllowEquals from './allow-equals.jsx';
 import MultipliersInfo from './Multiplier/info.jsx';
 import Multiplier from './Multiplier/multiplier.jsx';
+import TurbosInfo from './Turbos/turbos-info.jsx';
 
 const Input = ({
     amount,
@@ -171,6 +172,7 @@ const Amount = ({
                     />
                 </React.Fragment>
             )}
+            {is_turbos && <TurbosInfo className='trade-container__turbos-trade-info' />}
         </Fieldset>
     );
 };

--- a/packages/trader/src/Modules/Trading/Containers/trade-params-mobile.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade-params-mobile.jsx
@@ -174,20 +174,21 @@ export default connect(({ client, modules, ui }) => ({
 }))(TradeParamsModal);
 
 const TradeParamsMobile = ({
-    currency,
-    toggleModal,
-    isVisible,
-    setAmountTabIdx,
     amount_tab_idx,
-    setTradeParamTabIdx,
-    trade_param_tab_idx,
-    setDurationTabIdx,
+    currency,
     duration_unit,
     duration_units_list,
     duration_value,
     duration_tab_idx,
     has_amount_error,
     has_duration_error,
+    isVisible,
+    is_turbos,
+    setAmountTabIdx,
+    setTradeParamTabIdx,
+    setDurationTabIdx,
+    trade_param_tab_idx,
+    toggleModal,
     // amount
     setAmountError,
     setSelectedAmount,
@@ -237,7 +238,9 @@ const TradeParamsMobile = ({
             case 'amount':
                 return (
                     <div className='trade-params__header'>
-                        <div className='trade-params__header-label'>{localize('Amount')}</div>
+                        <div className='trade-params__header-label'>
+                            {is_turbos ? localize('Stake') : localize('Amount')}
+                        </div>
                         <div
                             className={classNames('trade-params__header-value', {
                                 'trade-params__header-value--has-error': has_amount_error,
@@ -301,6 +304,7 @@ const TradeParamsMobile = ({
 const TradeParamsMobileWrapper = connect(({ modules }) => ({
     basis_list: modules.trade.basis_list,
     basis: modules.trade.basis,
+    is_turbos: modules.trade.is_turbos,
 }))(TradeParamsMobile);
 
 export const LastDigitMobile = connect(({ modules }) => ({

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.js
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.js
@@ -134,6 +134,7 @@ export default class TradeStore extends BaseStore {
     // Turbos trade params
     number_of_contracts = 0;
     turbos_barrier_choices = [];
+    //TODO: clean up min_stake ans max_stake after BE will be ready
     min_stake = 1;
     max_stake = 100;
 

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.js
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.js
@@ -134,6 +134,8 @@ export default class TradeStore extends BaseStore {
     // Turbos trade params
     number_of_contracts = 0;
     turbos_barrier_choices = [];
+    min_stack = 1;
+    max_stack = 100;
 
     // Mobile
     is_trade_params_expanded = true;

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.js
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.js
@@ -134,8 +134,8 @@ export default class TradeStore extends BaseStore {
     // Turbos trade params
     number_of_contracts = 0;
     turbos_barrier_choices = [];
-    min_stack = 1;
-    max_stack = 100;
+    min_stake = 1;
+    max_stake = 100;
 
     // Mobile
     is_trade_params_expanded = true;

--- a/packages/trader/src/sass/app/modules/trading-mobile.scss
+++ b/packages/trader/src/sass/app/modules/trading-mobile.scss
@@ -185,7 +185,19 @@
                 }
             }
         }
-        &__amount {
+
+        &__amount,
+        &__stake {
+            &-container {
+                margin: 0.4rem 0 -0.7rem;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+
+                .trade-container__turbos-trade-info {
+                    width: 240px;
+                }
+            }
             &-keypad {
                 width: 100%;
                 padding: 1.6rem;

--- a/packages/trader/src/sass/app/modules/trading-mobile.scss
+++ b/packages/trader/src/sass/app/modules/trading-mobile.scss
@@ -195,7 +195,7 @@
                 justify-content: center;
 
                 .trade-container__turbos-trade-info {
-                    width: 240px;
+                    width: 24rem;
                 }
             }
             &-keypad {

--- a/packages/trader/src/sass/app/modules/trading.scss
+++ b/packages/trader/src/sass/app/modules/trading.scss
@@ -462,7 +462,8 @@
             }
         }
     }
-    &__multipliers-trade-info {
+    &__multipliers-trade-info,
+    &__turbos-trade-info {
         display: flex;
         justify-content: space-around;
         gap: 2.8rem;
@@ -476,6 +477,15 @@
 
             span {
                 border-bottom: 1px dotted var(--text-general);
+            }
+        }
+    }
+    &__turbos-trade-info {
+        justify-content: space-between;
+
+        &-tooltip-text {
+            span {
+                border-bottom: none;
             }
         }
     }


### PR DESCRIPTION
## Changes:

- Add new `TurbosInfo` component, which is based on existing `MultipliersInfo` component. It was necessary to create a new component as `MultipliersInfo` has too much extra properties, functions and child components (tooltips and etc.). Only for desktop.
- Add `Min. stake` and `Max. stake` values to the trade store, but they are temporary hardcoded as we should receive them from BE. **Do not forget to clean them up in future!**
- Add tabs for ticks and stake for mobile version based in existing component. 

## What is negotiable: 

- In the existing code we have 'header_content' attribute for div tag, but this attribute do not exist in official documentation https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes. It's also not a custom attribute, as all of them should start with 'data-'. Suggestion: we should rename all custom tags according to international agreement (with 'data-' prefix).
Example of usage:
`<div header_content={getHeaderContent('duration')}>`

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
