### PR TITLE
Kate/87506/To implement Turbos Contract card in Recent Positions drawer and Contract Details

### DIFF
--- a/packages/components/src/components/contract-card/contract-card-items/contract-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/contract-card-body.jsx
@@ -26,7 +26,6 @@ const ContractCardBody = ({
     has_progress_slider,
     is_mobile,
     is_multiplier,
-    is_positions,
     is_sold,
     is_turbos,
     onMouseLeave,
@@ -99,7 +98,6 @@ const ContractCardBody = ({
                 is_mobile={is_mobile}
                 removeToast={removeToast}
                 setCurrentFocus={setCurrentFocus}
-                is_positions={is_positions}
                 progress_slider_mobile_el={progress_slider_mobile_el}
             />
         );
@@ -189,7 +187,6 @@ ContractCardBody.propTypes = {
     getContractById: PropTypes.func,
     is_mobile: PropTypes.bool,
     is_multiplier: PropTypes.bool,
-    is_positions: PropTypes.bool,
     is_sold: PropTypes.bool,
     is_turbos: PropTypes.bool,
     onMouseLeave: PropTypes.func,

--- a/packages/components/src/components/contract-card/contract-card-items/contract-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/contract-card-body.jsx
@@ -96,9 +96,11 @@ const ContractCardBody = ({
                 is_sold={is_sold}
                 onMouseLeave={onMouseLeave}
                 status={status}
+                is_mobile={is_mobile}
                 removeToast={removeToast}
                 setCurrentFocus={setCurrentFocus}
                 is_positions={is_positions}
+                progress_slider_mobile_el={progress_slider_mobile_el}
             />
         );
     } else {
@@ -164,7 +166,7 @@ const ContractCardBody = ({
                     className={
                         ('dc-contract-card__separatorclass',
                         classNames({
-                            'dc-contract-card__body-wrapper': !is_multiplier,
+                            'dc-contract-card__body-wrapper': !is_multiplier && !is_turbos,
                         }))
                     }
                 >

--- a/packages/components/src/components/contract-card/contract-card-items/contract-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/contract-card-body.jsx
@@ -11,6 +11,7 @@ import Money from '../../money';
 import { ResultStatusIcon } from '../result-overlay/result-overlay.jsx';
 import ProgressSliderMobile from '../../progress-slider-mobile';
 import MultiplierCardBody from './multiplier-card-body.jsx';
+import TurbosCardBody from './turbos-card-body.jsx';
 
 const ContractCardBody = ({
     addToast,
@@ -25,7 +26,9 @@ const ContractCardBody = ({
     has_progress_slider,
     is_mobile,
     is_multiplier,
+    is_positions,
     is_sold,
+    is_turbos,
     onMouseLeave,
     removeToast,
     server_time,
@@ -76,6 +79,26 @@ const ContractCardBody = ({
                 setCurrentFocus={setCurrentFocus}
                 should_show_cancellation_warning={should_show_cancellation_warning}
                 toggleCancellationWarning={toggleCancellationWarning}
+            />
+        );
+    } else if (is_turbos) {
+        card_body = (
+            <TurbosCardBody
+                addToast={addToast}
+                connectWithContractUpdate={connectWithContractUpdate}
+                contract_info={contract_info}
+                contract_update={contract_update}
+                currency={currency}
+                current_focus={current_focus}
+                error_message_alignment={error_message_alignment}
+                getCardLabels={getCardLabels}
+                getContractById={getContractById}
+                is_sold={is_sold}
+                onMouseLeave={onMouseLeave}
+                status={status}
+                removeToast={removeToast}
+                setCurrentFocus={setCurrentFocus}
+                is_positions={is_positions}
             />
         );
     } else {
@@ -164,7 +187,9 @@ ContractCardBody.propTypes = {
     getContractById: PropTypes.func,
     is_mobile: PropTypes.bool,
     is_multiplier: PropTypes.bool,
+    is_positions: PropTypes.bool,
     is_sold: PropTypes.bool,
+    is_turbos: PropTypes.bool,
     onMouseLeave: PropTypes.func,
     removeToast: PropTypes.func,
     server_time: PropTypes.object,

--- a/packages/components/src/components/contract-card/contract-card-items/contract-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/contract-card-body.jsx
@@ -1,20 +1,8 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {
-    isCryptocurrency,
-    getCancellationPrice,
-    getIndicativePrice,
-    getLimitOrderAmount,
-    getCurrentTick,
-    getDisplayStatus,
-    getTotalProfit,
-    isValidToCancel,
-    isValidToSell,
-    shouldShowCancellation,
-} from '@deriv/shared';
+import { isCryptocurrency, getIndicativePrice, getCurrentTick, getDisplayStatus } from '@deriv/shared';
 import ContractCardItem from './contract-card-item.jsx';
-import ToggleCardDialog from './toggle-card-dialog.jsx';
 import CurrencyBadge from '../../currency-badge';
 import DesktopWrapper from '../../desktop-wrapper';
 import Icon from '../../icon';
@@ -22,130 +10,7 @@ import MobileWrapper from '../../mobile-wrapper';
 import Money from '../../money';
 import { ResultStatusIcon } from '../result-overlay/result-overlay.jsx';
 import ProgressSliderMobile from '../../progress-slider-mobile';
-
-const MultiplierCardBody = ({
-    addToast,
-    contract_info,
-    contract_update,
-    connectWithContractUpdate,
-    currency,
-    current_focus,
-    error_message_alignment,
-    getCardLabels,
-    getContractById,
-    has_progress_slider,
-    progress_slider,
-    is_mobile,
-    is_sold,
-    onMouseLeave,
-    removeToast,
-    setCurrentFocus,
-    should_show_cancellation_warning,
-    status,
-    toggleCancellationWarning,
-}) => {
-    const { buy_price, bid_price, profit, limit_order, underlying } = contract_info;
-
-    const total_profit = getTotalProfit(contract_info);
-    const { take_profit, stop_loss } = getLimitOrderAmount(contract_update || limit_order);
-    const cancellation_price = getCancellationPrice(contract_info);
-    const is_valid_to_cancel = isValidToCancel(contract_info);
-    const is_valid_to_sell = isValidToSell(contract_info);
-
-    return (
-        <React.Fragment>
-            <div
-                className={classNames({
-                    'dc-contract-card-items-wrapper--mobile': is_mobile,
-                    'dc-contract-card-items-wrapper': !is_mobile,
-                    'dc-contract-card-items-wrapper--has-progress-slider': has_progress_slider && !is_sold,
-                })}
-            >
-                <ContractCardItem header={getCardLabels().STAKE} className='dc-contract-card__stake'>
-                    <Money amount={buy_price - cancellation_price} currency={currency} />
-                </ContractCardItem>
-                <ContractCardItem header={getCardLabels().CURRENT_STAKE} className='dc-contract-card__current-stake'>
-                    <div
-                        className={classNames({
-                            'dc-contract-card--profit': +profit > 0,
-                            'dc-contract-card--loss': +profit < 0,
-                        })}
-                    >
-                        <Money amount={bid_price} currency={currency} />
-                    </div>
-                </ContractCardItem>
-                <ContractCardItem
-                    header={getCardLabels().DEAL_CANCEL_FEE}
-                    className='dc-contract-card__deal-cancel-fee'
-                >
-                    {cancellation_price ? (
-                        <Money amount={cancellation_price} currency={currency} />
-                    ) : (
-                        <React.Fragment>
-                            {shouldShowCancellation(underlying) ? <strong>-</strong> : getCardLabels().NOT_AVAILABLE}
-                        </React.Fragment>
-                    )}
-                </ContractCardItem>
-                <ContractCardItem header={getCardLabels().BUY_PRICE} className='dc-contract-card__buy-price'>
-                    <Money amount={buy_price} currency={currency} />
-                </ContractCardItem>
-                {has_progress_slider && is_mobile && !is_sold && (
-                    <ContractCardItem className='dc-contract-card__date-expiry'>{progress_slider}</ContractCardItem>
-                )}
-                <div className='dc-contract-card__limit-order-info'>
-                    <ContractCardItem header={getCardLabels().TAKE_PROFIT} className='dc-contract-card__take-profit'>
-                        {take_profit ? <Money amount={take_profit} currency={currency} /> : <strong>-</strong>}
-                    </ContractCardItem>
-                    <ContractCardItem header={getCardLabels().STOP_LOSS} className='dc-contract-card__stop-loss'>
-                        {stop_loss ? (
-                            <React.Fragment>
-                                <strong>-</strong>
-                                <Money amount={stop_loss} currency={currency} />
-                            </React.Fragment>
-                        ) : (
-                            <strong>-</strong>
-                        )}
-                    </ContractCardItem>
-                    {(is_valid_to_sell || is_valid_to_cancel) && (
-                        <ToggleCardDialog
-                            addToast={addToast}
-                            connectWithContractUpdate={connectWithContractUpdate}
-                            contract_id={contract_info.contract_id}
-                            current_focus={current_focus}
-                            error_message_alignment={error_message_alignment}
-                            getCardLabels={getCardLabels}
-                            getContractById={getContractById}
-                            is_valid_to_cancel={is_valid_to_cancel}
-                            onMouseLeave={onMouseLeave}
-                            removeToast={removeToast}
-                            setCurrentFocus={setCurrentFocus}
-                            should_show_cancellation_warning={should_show_cancellation_warning}
-                            status={status}
-                            toggleCancellationWarning={toggleCancellationWarning}
-                        />
-                    )}
-                </div>
-            </div>
-            <ContractCardItem
-                className='dc-contract-card-item__total-profit-loss'
-                header={getCardLabels().TOTAL_PROFIT_LOSS}
-                is_crypto={isCryptocurrency(currency)}
-                is_loss={+total_profit < 0}
-                is_won={+total_profit > 0}
-            >
-                <Money amount={total_profit} currency={currency} />
-                <div
-                    className={classNames('dc-contract-card__indicative--movement', {
-                        'dc-contract-card__indicative--movement-complete': is_sold,
-                    })}
-                >
-                    {status === 'profit' && <Icon icon='IcProfit' />}
-                    {status === 'loss' && <Icon icon='IcLoss' />}
-                </div>
-            </ContractCardItem>
-        </React.Fragment>
-    );
-};
+import MultiplierCardBody from './multiplier-card-body.jsx';
 
 const ContractCardBody = ({
     addToast,
@@ -172,6 +37,8 @@ const ContractCardBody = ({
     const indicative = getIndicativePrice(contract_info);
     const { buy_price, sell_price, payout, profit, tick_count, date_expiry, purchase_time } = contract_info;
     const current_tick = tick_count ? getCurrentTick(contract_info) : null;
+    const { INDICATIVE_PRICE, PAYOUT, POTENTIAL_PAYOUT, POTENTIAL_PROFIT_LOSS, PROFIT_LOSS, PURCHASE_PRICE } =
+        getCardLabels();
 
     const progress_slider_mobile_el = (
         <ProgressSliderMobile
@@ -185,79 +52,85 @@ const ContractCardBody = ({
         />
     );
 
-    const card_body = is_multiplier ? (
-        <MultiplierCardBody
-            addToast={addToast}
-            connectWithContractUpdate={connectWithContractUpdate}
-            contract_info={contract_info}
-            contract_update={contract_update}
-            currency={currency}
-            current_focus={current_focus}
-            error_message_alignment={error_message_alignment}
-            getCardLabels={getCardLabels}
-            getContractById={getContractById}
-            has_progress_slider={has_progress_slider}
-            progress_slider={progress_slider_mobile_el}
-            is_mobile={is_mobile}
-            is_sold={is_sold}
-            onMouseLeave={onMouseLeave}
-            status={status}
-            removeToast={removeToast}
-            setCurrentFocus={setCurrentFocus}
-            should_show_cancellation_warning={should_show_cancellation_warning}
-            toggleCancellationWarning={toggleCancellationWarning}
-        />
-    ) : (
-        <React.Fragment>
-            <div className='dc-contract-card-items-wrapper'>
-                <ContractCardItem
-                    header={is_sold ? getCardLabels().PROFIT_LOSS : getCardLabels().POTENTIAL_PROFIT_LOSS}
-                    is_crypto={isCryptocurrency(currency)}
-                    is_loss={+profit < 0}
-                    is_won={+profit > 0}
-                >
-                    <Money amount={profit} currency={currency} />
-                    <div
-                        className={classNames('dc-contract-card__indicative--movement', {
-                            'dc-contract-card__indicative--movement-complete': is_sold,
-                        })}
+    let card_body;
+
+    if (is_multiplier) {
+        card_body = (
+            <MultiplierCardBody
+                addToast={addToast}
+                connectWithContractUpdate={connectWithContractUpdate}
+                contract_info={contract_info}
+                contract_update={contract_update}
+                currency={currency}
+                current_focus={current_focus}
+                error_message_alignment={error_message_alignment}
+                getCardLabels={getCardLabels}
+                getContractById={getContractById}
+                has_progress_slider={has_progress_slider}
+                progress_slider={progress_slider_mobile_el}
+                is_mobile={is_mobile}
+                is_sold={is_sold}
+                onMouseLeave={onMouseLeave}
+                status={status}
+                removeToast={removeToast}
+                setCurrentFocus={setCurrentFocus}
+                should_show_cancellation_warning={should_show_cancellation_warning}
+                toggleCancellationWarning={toggleCancellationWarning}
+            />
+        );
+    } else {
+        card_body = (
+            <React.Fragment>
+                <div className='dc-contract-card-items-wrapper'>
+                    <ContractCardItem
+                        header={is_sold ? PROFIT_LOSS : POTENTIAL_PROFIT_LOSS}
+                        is_crypto={isCryptocurrency(currency)}
+                        is_loss={+profit < 0}
+                        is_won={+profit > 0}
                     >
-                        {status === 'profit' && <Icon icon='IcProfit' />}
-                        {status === 'loss' && <Icon icon='IcLoss' />}
-                    </div>
-                </ContractCardItem>
-                <ContractCardItem header={is_sold ? getCardLabels().PAYOUT : getCardLabels().INDICATIVE_PRICE}>
-                    <Money currency={currency} amount={sell_price || indicative} />
-                    <div
-                        className={classNames('dc-contract-card__indicative--movement', {
-                            'dc-contract-card__indicative--movement-complete': is_sold,
-                        })}
-                    >
-                        {status === 'profit' && <Icon icon='IcProfit' />}
-                        {status === 'loss' && <Icon icon='IcLoss' />}
-                    </div>
-                </ContractCardItem>
-                <ContractCardItem header={getCardLabels().PURCHASE_PRICE}>
-                    <Money amount={buy_price} currency={currency} />
-                </ContractCardItem>
-                <ContractCardItem header={getCardLabels().POTENTIAL_PAYOUT}>
-                    <Money currency={currency} amount={payout} />
-                </ContractCardItem>
-            </div>
-            <MobileWrapper>
-                <div className='dc-contract-card__status'>
-                    {is_sold ? (
-                        <ResultStatusIcon
-                            getCardLabels={getCardLabels}
-                            is_contract_won={getDisplayStatus(contract_info) === 'won'}
-                        />
-                    ) : (
-                        progress_slider_mobile_el
-                    )}
+                        <Money amount={profit} currency={currency} />
+                        <div
+                            className={classNames('dc-contract-card__indicative--movement', {
+                                'dc-contract-card__indicative--movement-complete': is_sold,
+                            })}
+                        >
+                            {status === 'profit' && <Icon icon='IcProfit' />}
+                            {status === 'loss' && <Icon icon='IcLoss' />}
+                        </div>
+                    </ContractCardItem>
+                    <ContractCardItem header={is_sold ? PAYOUT : INDICATIVE_PRICE}>
+                        <Money currency={currency} amount={sell_price || indicative} />
+                        <div
+                            className={classNames('dc-contract-card__indicative--movement', {
+                                'dc-contract-card__indicative--movement-complete': is_sold,
+                            })}
+                        >
+                            {status === 'profit' && <Icon icon='IcProfit' />}
+                            {status === 'loss' && <Icon icon='IcLoss' />}
+                        </div>
+                    </ContractCardItem>
+                    <ContractCardItem header={PURCHASE_PRICE}>
+                        <Money amount={buy_price} currency={currency} />
+                    </ContractCardItem>
+                    <ContractCardItem header={POTENTIAL_PAYOUT}>
+                        <Money currency={currency} amount={payout} />
+                    </ContractCardItem>
                 </div>
-            </MobileWrapper>
-        </React.Fragment>
-    );
+                <MobileWrapper>
+                    <div className='dc-contract-card__status'>
+                        {is_sold ? (
+                            <ResultStatusIcon
+                                getCardLabels={getCardLabels}
+                                is_contract_won={getDisplayStatus(contract_info) === 'won'}
+                            />
+                        ) : (
+                            progress_slider_mobile_el
+                        )}
+                    </div>
+                </MobileWrapper>
+            </React.Fragment>
+        );
+    }
 
     return (
         <React.Fragment>

--- a/packages/components/src/components/contract-card/contract-card-items/contract-card-header.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/contract-card-header.jsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { CSSTransition } from 'react-transition-group';
-import { isHighLow, getCurrentTick, isBot , getSubType, isTurbosContract, isMultiplierContract } from '@deriv/shared';
+import { isHighLow, getCurrentTick, isBot, getSubType, isTurbosContract, isMultiplierContract } from '@deriv/shared';
 import ContractTypeCell from './contract-type-cell.jsx';
 import Button from '../../button';
 import Icon from '../../icon';
@@ -47,7 +47,7 @@ const ContractCardHeader = ({
         )?.displayed_trade_text || '';
 
     return (
-        <>
+        <React.Fragment>
             <div
                 className={classNames('dc-contract-card__grid', 'dc-contract-card__grid-underlying-trade', {
                     'dc-contract-card__grid-underlying-trade--mobile': is_mobile && !multiplier,
@@ -113,7 +113,7 @@ const ContractCardHeader = ({
                     />
                 )}
             </DesktopWrapper>
-        </>
+        </React.Fragment>
     );
 };
 

--- a/packages/components/src/components/contract-card/contract-card-items/contract-card-header.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/contract-card-header.jsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { CSSTransition } from 'react-transition-group';
-import { isHighLow, getCurrentTick, isBot } from '@deriv/shared';
+import { isHighLow, getCurrentTick, isBot , getSubType, isTurbosContract, isMultiplierContract } from '@deriv/shared';
 import ContractTypeCell from './contract-type-cell.jsx';
 import Button from '../../button';
 import Icon from '../../icon';
@@ -28,6 +28,24 @@ const ContractCardHeader = ({
     const { underlying, multiplier, contract_type, shortcode, purchase_time, date_expiry, tick_count, is_sold } =
         contract_info;
 
+    const contract_type_list_info = [
+        {
+            value: 'Multiplier',
+            checkContractType: isMultiplierContract,
+            displayed_trade_text: `x${multiplier}`,
+        },
+        {
+            value: 'Turbos',
+            checkContractType: isTurbosContract,
+            displayed_trade_text: getSubType(contract_type),
+        },
+    ];
+
+    const displayed_trade_param =
+        contract_type_list_info.find(contract_type_item_info =>
+            contract_type_item_info.checkContractType(contract_type)
+        )?.displayed_trade_text || '';
+
     return (
         <>
             <div
@@ -44,9 +62,9 @@ const ContractCardHeader = ({
                 </div>
                 <div id='dc-contract_card_type_label' className='dc-contract-card__type'>
                     <ContractTypeCell
+                        displayed_trade_param={displayed_trade_param}
                         getContractTypeDisplay={getContractTypeDisplay}
                         is_high_low={isHighLow({ shortcode })}
-                        multiplier={multiplier}
                         type={contract_type}
                     />
                 </div>

--- a/packages/components/src/components/contract-card/contract-card-items/contract-type-cell.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/contract-type-cell.jsx
@@ -1,22 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import IconTradeTypes from '../../icon-trade-types';
+import { getSubType } from '@deriv/shared';
 
-const ContractTypeCell = ({ getContractTypeDisplay, is_high_low, multiplier, type }) => (
-    <div className='dc-contract-type'>
-        <div className='dc-contract-type__type-wrapper'>
-            <IconTradeTypes
-                type={is_high_low ? `${type.toLowerCase()}_barrier` : type.toLowerCase()}
-                className='category-type'
-                size={24}
-            />
+const ContractTypeCell = ({ getContractTypeDisplay, is_high_low, multiplier, type }) => {
+    let contract_type_display;
+    if (type.toLowerCase().includes('turbos')) {
+        contract_type_display = (
+            <div className='dc-contract-type__type-turbos'>
+                Turbos<span className='dc-contract-type__type-turbos-subtype'> {getSubType(type)}</span>
+            </div>
+        );
+    } else {
+        contract_type_display = <div>{getContractTypeDisplay(type, is_high_low) || ''}</div>;
+    }
+
+    return (
+        <div className='dc-contract-type'>
+            <div className='dc-contract-type__type-wrapper'>
+                <IconTradeTypes
+                    type={is_high_low ? `${type.toLowerCase()}_barrier` : type.toLowerCase()}
+                    className='category-type'
+                    size={24}
+                />
+            </div>
+            <div className='dc-contract-type__type-label'>
+                {contract_type_display}
+                {multiplier && <div className='dc-contract-type__type-label-multiplier'>x{multiplier}</div>}
+            </div>
         </div>
-        <div className='dc-contract-type__type-label'>
-            <div>{getContractTypeDisplay(type, is_high_low) || ''}</div>
-            {multiplier && <div className='dc-contract-type__type-label-multiplier'>x{multiplier}</div>}
-        </div>
-    </div>
-);
+    );
+};
 
 ContractTypeCell.propTypes = {
     getContractTypeDisplay: PropTypes.func,

--- a/packages/components/src/components/contract-card/contract-card-items/contract-type-cell.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/contract-type-cell.jsx
@@ -1,20 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import IconTradeTypes from '../../icon-trade-types';
-import { getSubType } from '@deriv/shared';
 
-const ContractTypeCell = ({ getContractTypeDisplay, is_high_low, multiplier, type }) => {
-    let contract_type_display;
-    if (type.toLowerCase().includes('turbos')) {
-        contract_type_display = (
-            <div className='dc-contract-type__type-turbos'>
-                Turbos<span className='dc-contract-type__type-turbos-subtype'> {getSubType(type)}</span>
-            </div>
-        );
-    } else {
-        contract_type_display = <div>{getContractTypeDisplay(type, is_high_low) || ''}</div>;
-    }
-
+const ContractTypeCell = ({ displayed_trade_param, getContractTypeDisplay, is_high_low, type }) => {
     return (
         <div className='dc-contract-type'>
             <div className='dc-contract-type__type-wrapper'>
@@ -25,17 +13,19 @@ const ContractTypeCell = ({ getContractTypeDisplay, is_high_low, multiplier, typ
                 />
             </div>
             <div className='dc-contract-type__type-label'>
-                {contract_type_display}
-                {multiplier && <div className='dc-contract-type__type-label-multiplier'>x{multiplier}</div>}
+                <div>{getContractTypeDisplay(type, is_high_low) || ''}</div>
+                {displayed_trade_param && (
+                    <div className='dc-contract-type__type-label-trade-param'>{displayed_trade_param}</div>
+                )}
             </div>
         </div>
     );
 };
 
 ContractTypeCell.propTypes = {
+    displayed_trade_param: PropTypes.string,
     getContractTypeDisplay: PropTypes.func,
     is_high_low: PropTypes.bool,
-    multiplier: PropTypes.number,
     type: PropTypes.string,
 };
 

--- a/packages/components/src/components/contract-card/contract-card-items/contract-type-cell.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/contract-type-cell.jsx
@@ -2,25 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import IconTradeTypes from '../../icon-trade-types';
 
-const ContractTypeCell = ({ displayed_trade_param, getContractTypeDisplay, is_high_low, type }) => {
-    return (
-        <div className='dc-contract-type'>
-            <div className='dc-contract-type__type-wrapper'>
-                <IconTradeTypes
-                    type={is_high_low ? `${type.toLowerCase()}_barrier` : type.toLowerCase()}
-                    className='category-type'
-                    size={24}
-                />
-            </div>
-            <div className='dc-contract-type__type-label'>
-                <div>{getContractTypeDisplay(type, is_high_low) || ''}</div>
-                {displayed_trade_param && (
-                    <div className='dc-contract-type__type-label-trade-param'>{displayed_trade_param}</div>
-                )}
-            </div>
+const ContractTypeCell = ({ displayed_trade_param, getContractTypeDisplay, is_high_low, type }) => (
+    <div className='dc-contract-type'>
+        <div className='dc-contract-type__type-wrapper'>
+            <IconTradeTypes
+                type={is_high_low ? `${type.toLowerCase()}_barrier` : type.toLowerCase()}
+                className='category-type'
+                size={24}
+            />
         </div>
-    );
-};
+        <div className='dc-contract-type__type-label'>
+            <div>{getContractTypeDisplay(type, is_high_low) || ''}</div>
+            {displayed_trade_param && (
+                <div className='dc-contract-type__type-label-trade-param'>{displayed_trade_param}</div>
+            )}
+        </div>
+    </div>
+);
 
 ContractTypeCell.propTypes = {
     displayed_trade_param: PropTypes.string,

--- a/packages/components/src/components/contract-card/contract-card-items/contract-update-form.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/contract-update-form.jsx
@@ -23,6 +23,7 @@ const ContractUpdateForm = props => {
         current_focus,
         error_message_alignment,
         getCardLabels,
+        is_accumulator,
         onMouseLeave,
         removeToast,
         setCurrentFocus,
@@ -63,7 +64,9 @@ const ContractUpdateForm = props => {
 
     const is_take_profit_valid = has_contract_update_take_profit ? contract_update_take_profit > 0 : isValid(stop_loss);
     const is_stop_loss_valid = has_contract_update_stop_loss ? contract_update_stop_loss > 0 : isValid(take_profit);
-    const is_valid_contract_update = is_valid_to_cancel ? false : !!(is_take_profit_valid || is_stop_loss_valid);
+    const is_valid_accu_contract_update = is_accumulator && !!is_take_profit_valid;
+    const is_valid_contract_update =
+        is_valid_accu_contract_update || (is_valid_to_cancel ? false : !!(is_take_profit_valid || is_stop_loss_valid));
 
     const getStateToCompare = _state => {
         const props_to_pick = [
@@ -116,7 +119,7 @@ const ContractUpdateForm = props => {
             onChange={onChange}
             error_message_alignment={error_message_alignment || 'right'}
             value={contract_profit_or_loss.contract_update_take_profit}
-            is_disabled={!!is_valid_to_cancel}
+            is_disabled={!is_accumulator && !!is_valid_to_cancel}
             setCurrentFocus={setCurrentFocus}
         />
     );
@@ -173,9 +176,13 @@ const ContractUpdateForm = props => {
                     </div>
                 </div>
             </MobileWrapper>
-            <div className='dc-contract-card-dialog__form'>
+            <div
+                className={classNames('dc-contract-card-dialog__form', {
+                    'dc-contract-card-dialog__form-accumulator': is_accumulator,
+                })}
+            >
                 <div className='dc-contract-card-dialog__input'>{take_profit_input}</div>
-                <div className='dc-contract-card-dialog__input'>{stop_loss_input}</div>
+                {!is_accumulator && <div className='dc-contract-card-dialog__input'>{stop_loss_input}</div>}
                 <div className='dc-contract-card-dialog__button'>
                     <Button
                         text={getCardLabels().APPLY}
@@ -195,6 +202,7 @@ ContractUpdateForm.propTypes = {
     current_focus: PropTypes.string,
     error_message_alignment: PropTypes.string,
     getCardLabels: PropTypes.func,
+    is_accumulator: PropTypes.bool,
     onMouseLeave: PropTypes.func,
     removeToast: PropTypes.func,
     setCurrentFocus: PropTypes.func,

--- a/packages/components/src/components/contract-card/contract-card-items/contract-update-form.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/contract-update-form.jsx
@@ -23,7 +23,7 @@ const ContractUpdateForm = props => {
         current_focus,
         error_message_alignment,
         getCardLabels,
-        is_accumulator,
+        is_turbos,
         onMouseLeave,
         removeToast,
         setCurrentFocus,
@@ -64,9 +64,10 @@ const ContractUpdateForm = props => {
 
     const is_take_profit_valid = has_contract_update_take_profit ? contract_update_take_profit > 0 : isValid(stop_loss);
     const is_stop_loss_valid = has_contract_update_stop_loss ? contract_update_stop_loss > 0 : isValid(take_profit);
-    const is_valid_accu_contract_update = is_accumulator && !!is_take_profit_valid;
+    const is_valid_turbos_contract_update = is_turbos && !!is_take_profit_valid;
     const is_valid_contract_update =
-        is_valid_accu_contract_update || (is_valid_to_cancel ? false : !!(is_take_profit_valid || is_stop_loss_valid));
+        is_valid_turbos_contract_update ||
+        (is_valid_to_cancel ? false : !!(is_take_profit_valid || is_stop_loss_valid));
 
     const getStateToCompare = _state => {
         const props_to_pick = [
@@ -119,7 +120,7 @@ const ContractUpdateForm = props => {
             onChange={onChange}
             error_message_alignment={error_message_alignment || 'right'}
             value={contract_profit_or_loss.contract_update_take_profit}
-            is_disabled={!is_accumulator && !!is_valid_to_cancel}
+            is_disabled={!is_turbos && !!is_valid_to_cancel}
             setCurrentFocus={setCurrentFocus}
         />
     );
@@ -178,11 +179,11 @@ const ContractUpdateForm = props => {
             </MobileWrapper>
             <div
                 className={classNames('dc-contract-card-dialog__form', {
-                    'dc-contract-card-dialog__form-accumulator': is_accumulator,
+                    'dc-contract-card-dialog__form-accumulator': is_turbos,
                 })}
             >
                 <div className='dc-contract-card-dialog__input'>{take_profit_input}</div>
-                {!is_accumulator && <div className='dc-contract-card-dialog__input'>{stop_loss_input}</div>}
+                {!is_turbos && <div className='dc-contract-card-dialog__input'>{stop_loss_input}</div>}
                 <div className='dc-contract-card-dialog__button'>
                     <Button
                         text={getCardLabels().APPLY}
@@ -202,7 +203,7 @@ ContractUpdateForm.propTypes = {
     current_focus: PropTypes.string,
     error_message_alignment: PropTypes.string,
     getCardLabels: PropTypes.func,
-    is_accumulator: PropTypes.bool,
+    is_turbos: PropTypes.bool,
     onMouseLeave: PropTypes.func,
     removeToast: PropTypes.func,
     setCurrentFocus: PropTypes.func,

--- a/packages/components/src/components/contract-card/contract-card-items/multiplier-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/multiplier-card-body.jsx
@@ -1,0 +1,171 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {
+    isCryptocurrency,
+    getCancellationPrice,
+    getLimitOrderAmount,
+    getTotalProfit,
+    isValidToCancel,
+    isValidToSell,
+    shouldShowCancellation,
+} from '@deriv/shared';
+import ContractCardItem from './contract-card-item.jsx';
+import ToggleCardDialog from './toggle-card-dialog.jsx';
+import Icon from '../../icon';
+import Money from '../../money';
+
+const MultiplierCardBody = ({
+    addToast,
+    contract_info,
+    contract_update,
+    connectWithContractUpdate,
+    currency,
+    current_focus,
+    error_message_alignment,
+    getCardLabels,
+    getContractById,
+    has_progress_slider,
+    progress_slider,
+    is_mobile,
+    is_sold,
+    onMouseLeave,
+    removeToast,
+    setCurrentFocus,
+    should_show_cancellation_warning,
+    status,
+    toggleCancellationWarning,
+}) => {
+    const { buy_price, bid_price, profit, limit_order, underlying } = contract_info;
+
+    const total_profit = getTotalProfit(contract_info);
+    const { take_profit, stop_loss } = getLimitOrderAmount(contract_update || limit_order);
+    const cancellation_price = getCancellationPrice(contract_info);
+    const is_valid_to_cancel = isValidToCancel(contract_info);
+    const is_valid_to_sell = isValidToSell(contract_info);
+    const {
+        BUY_PRICE,
+        CURRENT_STAKE,
+        DEAL_CANCEL_FEE,
+        NOT_AVAILABLE,
+        STAKE,
+        STOP_LOSS,
+        TAKE_PROFIT,
+        TOTAL_PROFIT_LOSS,
+    } = getCardLabels();
+
+    return (
+        <React.Fragment>
+            <div
+                className={classNames({
+                    'dc-contract-card-items-wrapper--mobile': is_mobile,
+                    'dc-contract-card-items-wrapper': !is_mobile,
+                    'dc-contract-card-items-wrapper--has-progress-slider': has_progress_slider && !is_sold,
+                })}
+            >
+                <ContractCardItem header={STAKE} className='dc-contract-card__stake'>
+                    <Money amount={buy_price - cancellation_price} currency={currency} />
+                </ContractCardItem>
+                <ContractCardItem header={CURRENT_STAKE} className='dc-contract-card__current-stake'>
+                    <div
+                        className={classNames({
+                            'dc-contract-card--profit': +profit > 0,
+                            'dc-contract-card--loss': +profit < 0,
+                        })}
+                    >
+                        <Money amount={bid_price} currency={currency} />
+                    </div>
+                </ContractCardItem>
+                <ContractCardItem header={DEAL_CANCEL_FEE} className='dc-contract-card__deal-cancel-fee'>
+                    {cancellation_price ? (
+                        <Money amount={cancellation_price} currency={currency} />
+                    ) : (
+                        <React.Fragment>
+                            {shouldShowCancellation(underlying) ? <strong>-</strong> : NOT_AVAILABLE}
+                        </React.Fragment>
+                    )}
+                </ContractCardItem>
+                <ContractCardItem header={BUY_PRICE} className='dc-contract-card__buy-price'>
+                    <Money amount={buy_price} currency={currency} />
+                </ContractCardItem>
+                {has_progress_slider && is_mobile && !is_sold && (
+                    <ContractCardItem className='dc-contract-card__date-expiry'>{progress_slider}</ContractCardItem>
+                )}
+                <div className='dc-contract-card__limit-order-info'>
+                    <ContractCardItem header={TAKE_PROFIT} className='dc-contract-card__take-profit'>
+                        {take_profit ? <Money amount={take_profit} currency={currency} /> : <strong>-</strong>}
+                    </ContractCardItem>
+                    <ContractCardItem header={STOP_LOSS} className='dc-contract-card__stop-loss'>
+                        {stop_loss ? (
+                            <React.Fragment>
+                                <strong>-</strong>
+                                <Money amount={stop_loss} currency={currency} />
+                            </React.Fragment>
+                        ) : (
+                            <strong>-</strong>
+                        )}
+                    </ContractCardItem>
+                    {(is_valid_to_sell || is_valid_to_cancel) && (
+                        <ToggleCardDialog
+                            addToast={addToast}
+                            connectWithContractUpdate={connectWithContractUpdate}
+                            contract_id={contract_info.contract_id}
+                            current_focus={current_focus}
+                            error_message_alignment={error_message_alignment}
+                            getCardLabels={getCardLabels}
+                            getContractById={getContractById}
+                            is_valid_to_cancel={is_valid_to_cancel}
+                            onMouseLeave={onMouseLeave}
+                            removeToast={removeToast}
+                            setCurrentFocus={setCurrentFocus}
+                            should_show_cancellation_warning={should_show_cancellation_warning}
+                            status={status}
+                            toggleCancellationWarning={toggleCancellationWarning}
+                        />
+                    )}
+                </div>
+            </div>
+            <ContractCardItem
+                className='dc-contract-card-item__total-profit-loss'
+                header={TOTAL_PROFIT_LOSS}
+                is_crypto={isCryptocurrency(currency)}
+                is_loss={+total_profit < 0}
+                is_won={+total_profit > 0}
+            >
+                <Money amount={total_profit} currency={currency} />
+                <div
+                    className={classNames('dc-contract-card__indicative--movement', {
+                        'dc-contract-card__indicative--movement-complete': is_sold,
+                    })}
+                >
+                    {status === 'profit' && <Icon icon='IcProfit' />}
+                    {status === 'loss' && <Icon icon='IcLoss' />}
+                </div>
+            </ContractCardItem>
+        </React.Fragment>
+    );
+};
+
+MultiplierCardBody.propTypes = {
+    addToast: PropTypes.func,
+    connectWithContractUpdate: PropTypes.func,
+    contract_info: PropTypes.object,
+    contract_update: PropTypes.object,
+    currency: PropTypes.string,
+    current_focus: PropTypes.string,
+    error_message_alignment: PropTypes.string,
+    getCardLabels: PropTypes.func,
+    getContractById: PropTypes.func,
+    is_mobile: PropTypes.bool,
+    is_sold: PropTypes.bool,
+    onMouseLeave: PropTypes.func,
+    progress_slider: PropTypes.node,
+    removeToast: PropTypes.func,
+    setCurrentFocus: PropTypes.func,
+    should_show_cancellation_warning: PropTypes.bool,
+    status: PropTypes.string,
+    toggleCancellationWarning: PropTypes.func,
+    has_progress_slider: PropTypes.bool,
+};
+
+export default React.memo(MultiplierCardBody);

--- a/packages/components/src/components/contract-card/contract-card-items/toggle-card-dialog.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/toggle-card-dialog.jsx
@@ -22,6 +22,7 @@ const ToggleCardDialog = ({
     error_message_alignment,
     getCardLabels,
     getContractById,
+    is_accumulator,
     is_valid_to_cancel,
     onMouseLeave,
     removeToast,
@@ -152,6 +153,7 @@ const ToggleCardDialog = ({
                                 error_message_alignment={error_message_alignment}
                                 getCardLabels={getCardLabels}
                                 getContractById={getContractById}
+                                is_accumulator={is_accumulator}
                                 onMouseLeave={onMouseLeave}
                                 removeToast={removeToast}
                                 setCurrentFocus={setCurrentFocus}
@@ -179,6 +181,7 @@ const ToggleCardDialog = ({
                             error_message_alignment={error_message_alignment}
                             getCardLabels={getCardLabels}
                             getContractById={getContractById}
+                            is_accumulator={is_accumulator}
                             onMouseLeave={onMouseLeave}
                             removeToast={removeToast}
                             setCurrentFocus={setCurrentFocus}
@@ -202,6 +205,7 @@ ToggleCardDialog.propTypes = {
     error_message_alignment: PropTypes.string,
     getCardLabels: PropTypes.func,
     getContractById: PropTypes.func,
+    is_accumulator: PropTypes.bool,
     is_valid_to_cancel: PropTypes.bool,
     onMouseLeave: PropTypes.func,
     removeToast: PropTypes.func,

--- a/packages/components/src/components/contract-card/contract-card-items/toggle-card-dialog.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/toggle-card-dialog.jsx
@@ -22,7 +22,7 @@ const ToggleCardDialog = ({
     error_message_alignment,
     getCardLabels,
     getContractById,
-    is_accumulator,
+    is_turbos,
     is_valid_to_cancel,
     onMouseLeave,
     removeToast,
@@ -153,7 +153,7 @@ const ToggleCardDialog = ({
                                 error_message_alignment={error_message_alignment}
                                 getCardLabels={getCardLabels}
                                 getContractById={getContractById}
-                                is_accumulator={is_accumulator}
+                                is_turbos={is_turbos}
                                 onMouseLeave={onMouseLeave}
                                 removeToast={removeToast}
                                 setCurrentFocus={setCurrentFocus}
@@ -181,7 +181,7 @@ const ToggleCardDialog = ({
                             error_message_alignment={error_message_alignment}
                             getCardLabels={getCardLabels}
                             getContractById={getContractById}
-                            is_accumulator={is_accumulator}
+                            is_turbos={is_turbos}
                             onMouseLeave={onMouseLeave}
                             removeToast={removeToast}
                             setCurrentFocus={setCurrentFocus}
@@ -205,7 +205,7 @@ ToggleCardDialog.propTypes = {
     error_message_alignment: PropTypes.string,
     getCardLabels: PropTypes.func,
     getContractById: PropTypes.func,
-    is_accumulator: PropTypes.bool,
+    is_turbos: PropTypes.bool,
     is_valid_to_cancel: PropTypes.bool,
     onMouseLeave: PropTypes.func,
     removeToast: PropTypes.func,

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
@@ -89,7 +89,7 @@ const TurbosCardBody = ({
                     </div>
                 )}
                 <MobileWrapper>
-                    <div className='dc-contract-card__status-mobile'>
+                    <div className='dc-contract-card__status'>
                         {is_sold ? (
                             <ResultStatusIcon getCardLabels={getCardLabels} is_contract_won={+profit > 0} />
                         ) : (

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
@@ -39,7 +39,7 @@ const TurbosCardBody = ({
         <React.Fragment>
             <div className={is_mobile ? 'dc-contract-card-items-wrapper--mobile' : 'dc-contract-card-items-wrapper'}>
                 <ContractCardItem
-                    className={'dc-contract-card__stake'}
+                    className='dc-contract-card__stake'
                     header={is_sold ? PROFIT_LOSS : STAKE}
                     is_crypto={isCryptocurrency(currency)}
                     is_loss={is_sold ? +profit < 0 : false}
@@ -47,26 +47,23 @@ const TurbosCardBody = ({
                 >
                     <Money amount={buy_price} currency={currency} />
                 </ContractCardItem>
-                <ContractCardItem
-                    header={is_sold ? PAYOUT : CURRENT_PRICE}
-                    className={'dc-contract-card__current-price'}
-                >
+                <ContractCardItem header={is_sold ? PAYOUT : CURRENT_PRICE} className='dc-contract-card__current-price'>
                     <Money currency={currency} amount={sell_spot || current_spot_display_value} />
                 </ContractCardItem>
                 <ContractCardItem
                     header={is_sold ? BUY_PRICE : BARRIER_LEVEL}
                     is_crypto={isCryptocurrency(currency)}
-                    className={'dc-contract-card__buy-price'}
+                    className='dc-contract-card__buy-price'
                 >
                     <Money amount={is_sold ? entry_spot : barrier} currency={currency} />
                 </ContractCardItem>
 
                 {is_sold ? (
-                    <ContractCardItem header={BARRIER_LEVEL} className={'dc-contract-card__barrier-level'}>
+                    <ContractCardItem header={BARRIER_LEVEL} className='dc-contract-card__barrier-level'>
                         <Money amount={barrier} currency={currency} />
                     </ContractCardItem>
                 ) : (
-                    <div className={'dc-contract-card__limit-order-info'}>
+                    <div className='dc-contract-card__limit-order-info'>
                         <ContractCardItem header={TAKE_PROFIT} className='dc-contract-card__take-profit'>
                             {take_profit ? <Money amount={take_profit} currency={currency} /> : <strong>-</strong>}
                             {is_valid_to_sell && (

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
@@ -37,7 +37,7 @@ const TurbosCardBody = ({
 
     return (
         <React.Fragment>
-            <div className={is_mobile ? 'dc-contract-card-items-wrapper-mobile' : 'dc-contract-card-items-wrapper'}>
+            <div className={is_mobile ? 'dc-contract-card-items-wrapper--mobile' : 'dc-contract-card-items-wrapper'}>
                 <ContractCardItem
                     className={is_mobile ? 'dc-contract-card__stake-mobile' : 'dc-contract-card__stake'}
                     header={is_sold ? PROFIT_LOSS : STAKE}

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
@@ -49,14 +49,14 @@ const TurbosCardBody = ({
                 </ContractCardItem>
                 <ContractCardItem
                     header={is_sold ? PAYOUT : CURRENT_PRICE}
-                    className={is_mobile && 'dc-contract-card__current-price-mobile'}
+                    className={is_mobile ? 'dc-contract-card__current-price-mobile' : ''}
                 >
                     <Money currency={currency} amount={sell_spot || current_spot_display_value} />
                 </ContractCardItem>
                 <ContractCardItem
                     header={is_sold ? BUY_PRICE : BARRIER_LEVEL}
                     is_crypto={isCryptocurrency(currency)}
-                    className={is_mobile && 'dc-contract-card__buy-price-mobile'}
+                    className={is_mobile ? 'dc-contract-card__buy-price-mobile' : ''}
                 >
                     <Money amount={is_sold ? entry_spot : barrier} currency={currency} />
                 </ContractCardItem>
@@ -64,7 +64,7 @@ const TurbosCardBody = ({
                 {is_sold ? (
                     <ContractCardItem
                         header={BARRIER_LEVEL}
-                        className={is_mobile && 'dc-contract-card__barrier-level-mobile'}
+                        className={is_mobile ? 'dc-contract-card__barrier-level-mobile' : ''}
                     >
                         <Money amount={barrier} currency={currency} />
                     </ContractCardItem>
@@ -108,23 +108,25 @@ const TurbosCardBody = ({
                 </MobileWrapper>
             </div>
 
-            <ContractCardItem
-                className='dc-contract-card-item__total-profit-loss'
-                header={TOTAL_PROFIT_LOSS}
-                is_crypto={isCryptocurrency(currency)}
-                is_loss={+total_profit < 0}
-                is_won={+total_profit > 0}
-            >
-                <Money amount={total_profit} currency={currency} />
-                <div
-                    className={classNames('dc-contract-card__indicative--movement', {
-                        'dc-contract-card__indicative--movement-complete': is_sold,
-                    })}
+            {!is_sold && (
+                <ContractCardItem
+                    className='dc-contract-card-item__total-profit-loss'
+                    header={TOTAL_PROFIT_LOSS}
+                    is_crypto={isCryptocurrency(currency)}
+                    is_loss={+total_profit < 0}
+                    is_won={+total_profit > 0}
                 >
-                    {status === 'profit' && <Icon icon='IcProfit' />}
-                    {status === 'loss' && <Icon icon='IcLoss' />}
-                </div>
-            </ContractCardItem>
+                    <Money amount={total_profit} currency={currency} />
+                    <div
+                        className={classNames('dc-contract-card__indicative--movement', {
+                            'dc-contract-card__indicative--movement-complete': is_sold,
+                        })}
+                    >
+                        {status === 'profit' && <Icon icon='IcProfit' />}
+                        {status === 'loss' && <Icon icon='IcLoss' />}
+                    </div>
+                </ContractCardItem>
+            )}
         </React.Fragment>
     );
 };

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
@@ -87,7 +87,7 @@ const TurbosCardBody = ({
                                     error_message_alignment={error_message_alignment}
                                     getCardLabels={getCardLabels}
                                     getContractById={getContractById}
-                                    is_accumulator
+                                    is_turbos
                                     onMouseLeave={onMouseLeave}
                                     removeToast={removeToast}
                                     setCurrentFocus={setCurrentFocus}

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
@@ -139,7 +139,6 @@ TurbosCardBody.propTypes = {
     error_message_alignment: PropTypes.string,
     getCardLabels: PropTypes.func,
     getContractById: PropTypes.func,
-    is_positions: PropTypes.bool,
     is_sold: PropTypes.bool,
     is_mobile: PropTypes.bool,
     onMouseLeave: PropTypes.func,

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
@@ -39,7 +39,7 @@ const TurbosCardBody = ({
         <React.Fragment>
             <div className={is_mobile ? 'dc-contract-card-items-wrapper--mobile' : 'dc-contract-card-items-wrapper'}>
                 <ContractCardItem
-                    className={is_mobile ? 'dc-contract-card__stake-mobile' : 'dc-contract-card__stake'}
+                    className={'dc-contract-card__stake'}
                     header={is_sold ? PROFIT_LOSS : STAKE}
                     is_crypto={isCryptocurrency(currency)}
                     is_loss={is_sold ? +profit < 0 : false}
@@ -49,33 +49,24 @@ const TurbosCardBody = ({
                 </ContractCardItem>
                 <ContractCardItem
                     header={is_sold ? PAYOUT : CURRENT_PRICE}
-                    className={is_mobile ? 'dc-contract-card__current-price-mobile' : ''}
+                    className={'dc-contract-card__current-price'}
                 >
                     <Money currency={currency} amount={sell_spot || current_spot_display_value} />
                 </ContractCardItem>
                 <ContractCardItem
                     header={is_sold ? BUY_PRICE : BARRIER_LEVEL}
                     is_crypto={isCryptocurrency(currency)}
-                    className={is_mobile ? 'dc-contract-card__buy-price-mobile' : ''}
+                    className={'dc-contract-card__buy-price'}
                 >
                     <Money amount={is_sold ? entry_spot : barrier} currency={currency} />
                 </ContractCardItem>
 
                 {is_sold ? (
-                    <ContractCardItem
-                        header={BARRIER_LEVEL}
-                        className={is_mobile ? 'dc-contract-card__barrier-level-mobile' : ''}
-                    >
+                    <ContractCardItem header={BARRIER_LEVEL} className={'dc-contract-card__barrier-level'}>
                         <Money amount={barrier} currency={currency} />
                     </ContractCardItem>
                 ) : (
-                    <div
-                        className={
-                            is_mobile
-                                ? 'dc-contract-card__limit-order-info-mobile'
-                                : 'dc-contract-card__limit-order-info'
-                        }
-                    >
+                    <div className={'dc-contract-card__limit-order-info'}>
                         <ContractCardItem header={TAKE_PROFIT} className='dc-contract-card__take-profit'>
                             {take_profit ? <Money amount={take_profit} currency={currency} /> : <strong>-</strong>}
                             {is_valid_to_sell && (

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
@@ -24,7 +24,8 @@ const TurbosCardBody = ({
     removeToast,
     setCurrentFocus,
     status,
-    is_positions,
+    is_mobile,
+    progress_slider_mobile_el,
 }) => {
     const total_profit = getTotalProfit(contract_info);
     const { buy_price, profit, limit_order, barrier, current_spot_display_value, sell_spot, entry_spot } =
@@ -36,9 +37,9 @@ const TurbosCardBody = ({
 
     return (
         <React.Fragment>
-            <div className='dc-contract-card-items-wrapper'>
+            <div className={is_mobile ? 'dc-contract-card-items-wrapper-mobile' : 'dc-contract-card-items-wrapper'}>
                 <ContractCardItem
-                    className='dc-contract-card__stake'
+                    className={is_mobile ? 'dc-contract-card__stake-mobile' : 'dc-contract-card__stake'}
                     header={is_sold ? PROFIT_LOSS : STAKE}
                     is_crypto={isCryptocurrency(currency)}
                     is_loss={is_sold ? +profit < 0 : false}
@@ -46,73 +47,84 @@ const TurbosCardBody = ({
                 >
                     <Money amount={buy_price} currency={currency} />
                 </ContractCardItem>
-                <ContractCardItem header={is_sold ? PAYOUT : CURRENT_PRICE}>
+                <ContractCardItem
+                    header={is_sold ? PAYOUT : CURRENT_PRICE}
+                    className={is_mobile && 'dc-contract-card__current-price-mobile'}
+                >
                     <Money currency={currency} amount={sell_spot || current_spot_display_value} />
                 </ContractCardItem>
-                <ContractCardItem header={is_sold ? BUY_PRICE : BARRIER_LEVEL} is_crypto={isCryptocurrency(currency)}>
+                <ContractCardItem
+                    header={is_sold ? BUY_PRICE : BARRIER_LEVEL}
+                    is_crypto={isCryptocurrency(currency)}
+                    className={is_mobile && 'dc-contract-card__buy-price-mobile'}
+                >
                     <Money amount={is_sold ? entry_spot : barrier} currency={currency} />
                 </ContractCardItem>
-                <div className='dc-contract-card__limit-order-info'>
+
+                {is_sold ? (
                     <ContractCardItem
-                        header={is_sold ? BARRIER_LEVEL : TAKE_PROFIT}
-                        className='dc-contract-card__take-profit'
+                        header={BARRIER_LEVEL}
+                        className={is_mobile && 'dc-contract-card__barrier-level-mobile'}
                     >
-                        {take_profit ? (
-                            <Money amount={take_profit} currency={currency} />
-                        ) : is_sold ? (
-                            <Money amount={barrier} currency={currency} />
-                        ) : (
-                            <strong>-</strong>
-                        )}
-                        {is_valid_to_sell && (
-                            <ToggleCardDialog
-                                addToast={addToast}
-                                connectWithContractUpdate={connectWithContractUpdate}
-                                contract_id={contract_info.contract_id}
-                                current_focus={current_focus}
-                                error_message_alignment={error_message_alignment}
-                                getCardLabels={getCardLabels}
-                                getContractById={getContractById}
-                                is_accumulator
-                                onMouseLeave={onMouseLeave}
-                                removeToast={removeToast}
-                                setCurrentFocus={setCurrentFocus}
-                                status={status}
-                            />
-                        )}
+                        <Money amount={barrier} currency={currency} />
                     </ContractCardItem>
-                </div>
-            </div>
-            {!is_sold && (
-                <ContractCardItem
-                    className='dc-contract-card-item__total-profit-loss'
-                    header={TOTAL_PROFIT_LOSS}
-                    is_crypto={isCryptocurrency(currency)}
-                    is_loss={+total_profit < 0}
-                    is_won={+total_profit > 0}
-                >
-                    <Money amount={total_profit} currency={currency} />
+                ) : (
                     <div
-                        className={classNames('dc-contract-card__indicative--movement', {
-                            'dc-contract-card__indicative--movement-complete': is_sold,
-                        })}
+                        className={
+                            is_mobile
+                                ? 'dc-contract-card__limit-order-info-mobile'
+                                : 'dc-contract-card__limit-order-info'
+                        }
                     >
-                        {status === 'profit' && <Icon icon='IcProfit' />}
-                        {status === 'loss' && <Icon icon='IcLoss' />}
+                        <ContractCardItem header={TAKE_PROFIT} className='dc-contract-card__take-profit'>
+                            {take_profit ? <Money amount={take_profit} currency={currency} /> : <strong>-</strong>}
+                            {is_valid_to_sell && (
+                                <ToggleCardDialog
+                                    addToast={addToast}
+                                    connectWithContractUpdate={connectWithContractUpdate}
+                                    contract_id={contract_info.contract_id}
+                                    current_focus={current_focus}
+                                    error_message_alignment={error_message_alignment}
+                                    getCardLabels={getCardLabels}
+                                    getContractById={getContractById}
+                                    is_accumulator
+                                    onMouseLeave={onMouseLeave}
+                                    removeToast={removeToast}
+                                    setCurrentFocus={setCurrentFocus}
+                                    status={status}
+                                />
+                            )}
+                        </ContractCardItem>
                     </div>
-                </ContractCardItem>
-            )}
-            {!!is_sold && (
+                )}
                 <MobileWrapper>
-                    <div
-                        className={classNames('dc-contract-card__status', {
-                            'dc-contract-card__status--accumulator-mobile-positions': is_positions,
-                        })}
-                    >
-                        <ResultStatusIcon getCardLabels={getCardLabels} is_contract_won={+profit > 0} />
+                    <div className='dc-contract-card__status-mobile'>
+                        {is_sold ? (
+                            <ResultStatusIcon getCardLabels={getCardLabels} is_contract_won={+profit > 0} />
+                        ) : (
+                            progress_slider_mobile_el
+                        )}
                     </div>
                 </MobileWrapper>
-            )}
+            </div>
+
+            <ContractCardItem
+                className='dc-contract-card-item__total-profit-loss'
+                header={TOTAL_PROFIT_LOSS}
+                is_crypto={isCryptocurrency(currency)}
+                is_loss={+total_profit < 0}
+                is_won={+total_profit > 0}
+            >
+                <Money amount={total_profit} currency={currency} />
+                <div
+                    className={classNames('dc-contract-card__indicative--movement', {
+                        'dc-contract-card__indicative--movement-complete': is_sold,
+                    })}
+                >
+                    {status === 'profit' && <Icon icon='IcProfit' />}
+                    {status === 'loss' && <Icon icon='IcLoss' />}
+                </div>
+            </ContractCardItem>
         </React.Fragment>
     );
 };
@@ -129,8 +141,10 @@ TurbosCardBody.propTypes = {
     getContractById: PropTypes.func,
     is_positions: PropTypes.bool,
     is_sold: PropTypes.bool,
+    is_mobile: PropTypes.bool,
     onMouseLeave: PropTypes.func,
     removeToast: PropTypes.func,
+    progress_slider_mobile_el: PropTypes.node,
     setCurrentFocus: PropTypes.func,
     status: PropTypes.string,
 };

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.jsx
@@ -1,0 +1,138 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { isCryptocurrency, getLimitOrderAmount, getTotalProfit, isValidToSell } from '@deriv/shared';
+import ContractCardItem from './contract-card-item.jsx';
+import ToggleCardDialog from './toggle-card-dialog.jsx';
+import Icon from '../../icon';
+import MobileWrapper from '../../mobile-wrapper';
+import Money from '../../money';
+import { ResultStatusIcon } from '../result-overlay/result-overlay.jsx';
+
+const TurbosCardBody = ({
+    addToast,
+    connectWithContractUpdate,
+    contract_info,
+    contract_update,
+    currency,
+    current_focus,
+    error_message_alignment,
+    getCardLabels,
+    getContractById,
+    is_sold,
+    onMouseLeave,
+    removeToast,
+    setCurrentFocus,
+    status,
+    is_positions,
+}) => {
+    const total_profit = getTotalProfit(contract_info);
+    const { buy_price, profit, limit_order, barrier, current_spot_display_value, sell_spot, entry_spot } =
+        contract_info;
+    const { take_profit } = getLimitOrderAmount(contract_update || limit_order);
+    const is_valid_to_sell = isValidToSell(contract_info);
+    const { BARRIER_LEVEL, BUY_PRICE, CURRENT_PRICE, STAKE, TAKE_PROFIT, TOTAL_PROFIT_LOSS, PAYOUT, PROFIT_LOSS } =
+        getCardLabels();
+
+    return (
+        <React.Fragment>
+            <div className='dc-contract-card-items-wrapper'>
+                <ContractCardItem
+                    className='dc-contract-card__stake'
+                    header={is_sold ? PROFIT_LOSS : STAKE}
+                    is_crypto={isCryptocurrency(currency)}
+                    is_loss={is_sold ? +profit < 0 : false}
+                    is_won={is_sold ? +profit > 0 : false}
+                >
+                    <Money amount={buy_price} currency={currency} />
+                </ContractCardItem>
+                <ContractCardItem header={is_sold ? PAYOUT : CURRENT_PRICE}>
+                    <Money currency={currency} amount={sell_spot || current_spot_display_value} />
+                </ContractCardItem>
+                <ContractCardItem header={is_sold ? BUY_PRICE : BARRIER_LEVEL} is_crypto={isCryptocurrency(currency)}>
+                    <Money amount={is_sold ? entry_spot : barrier} currency={currency} />
+                </ContractCardItem>
+                <div className='dc-contract-card__limit-order-info'>
+                    <ContractCardItem
+                        header={is_sold ? BARRIER_LEVEL : TAKE_PROFIT}
+                        className='dc-contract-card__take-profit'
+                    >
+                        {take_profit ? (
+                            <Money amount={take_profit} currency={currency} />
+                        ) : is_sold ? (
+                            <Money amount={barrier} currency={currency} />
+                        ) : (
+                            <strong>-</strong>
+                        )}
+                        {is_valid_to_sell && (
+                            <ToggleCardDialog
+                                addToast={addToast}
+                                connectWithContractUpdate={connectWithContractUpdate}
+                                contract_id={contract_info.contract_id}
+                                current_focus={current_focus}
+                                error_message_alignment={error_message_alignment}
+                                getCardLabels={getCardLabels}
+                                getContractById={getContractById}
+                                is_accumulator
+                                onMouseLeave={onMouseLeave}
+                                removeToast={removeToast}
+                                setCurrentFocus={setCurrentFocus}
+                                status={status}
+                            />
+                        )}
+                    </ContractCardItem>
+                </div>
+            </div>
+            {!is_sold && (
+                <ContractCardItem
+                    className='dc-contract-card-item__total-profit-loss'
+                    header={TOTAL_PROFIT_LOSS}
+                    is_crypto={isCryptocurrency(currency)}
+                    is_loss={+total_profit < 0}
+                    is_won={+total_profit > 0}
+                >
+                    <Money amount={total_profit} currency={currency} />
+                    <div
+                        className={classNames('dc-contract-card__indicative--movement', {
+                            'dc-contract-card__indicative--movement-complete': is_sold,
+                        })}
+                    >
+                        {status === 'profit' && <Icon icon='IcProfit' />}
+                        {status === 'loss' && <Icon icon='IcLoss' />}
+                    </div>
+                </ContractCardItem>
+            )}
+            {!!is_sold && (
+                <MobileWrapper>
+                    <div
+                        className={classNames('dc-contract-card__status', {
+                            'dc-contract-card__status--accumulator-mobile-positions': is_positions,
+                        })}
+                    >
+                        <ResultStatusIcon getCardLabels={getCardLabels} is_contract_won={+profit > 0} />
+                    </div>
+                </MobileWrapper>
+            )}
+        </React.Fragment>
+    );
+};
+
+TurbosCardBody.propTypes = {
+    addToast: PropTypes.func,
+    connectWithContractUpdate: PropTypes.func,
+    contract_info: PropTypes.object,
+    contract_update: PropTypes.object,
+    currency: PropTypes.string,
+    current_focus: PropTypes.string,
+    error_message_alignment: PropTypes.string,
+    getCardLabels: PropTypes.func,
+    getContractById: PropTypes.func,
+    is_positions: PropTypes.bool,
+    is_sold: PropTypes.bool,
+    onMouseLeave: PropTypes.func,
+    removeToast: PropTypes.func,
+    setCurrentFocus: PropTypes.func,
+    status: PropTypes.string,
+};
+
+export default React.memo(TurbosCardBody);

--- a/packages/components/src/components/contract-card/contract-card.jsx
+++ b/packages/components/src/components/contract-card/contract-card.jsx
@@ -17,6 +17,7 @@ const ContractCard = ({
     getContractPath,
     is_multiplier,
     is_positions,
+    is_turbos,
     is_unsupported,
     onClickRemove,
     profit_loss,
@@ -36,6 +37,7 @@ const ContractCard = ({
                         getContractPath={getContractPath}
                         is_unsupported={is_unsupported}
                         is_multiplier={is_multiplier}
+                        is_turbos={is_turbos}
                         is_visible={!!contract_info.is_sold}
                         onClickRemove={onClickRemove}
                         onClick={() => toggleUnsupportedContractModal(true)}
@@ -64,6 +66,7 @@ ContractCard.propTypes = {
     getContractPath: PropTypes.func,
     is_multiplier: PropTypes.bool,
     is_positions: PropTypes.bool,
+    is_turbos: PropTypes.bool,
     is_unsupported: PropTypes.bool,
     onClickRemove: PropTypes.func,
     profit_loss: PropTypes.number,

--- a/packages/components/src/components/contract-card/contract-card.scss
+++ b/packages/components/src/components/contract-card/contract-card.scss
@@ -294,6 +294,12 @@
                     grid-column: 2/2;
                     position: relative;
                 }
+                &__status {
+                    align-self: center;
+                    justify-self: center;
+                    grid-row: 1/3;
+                    grid-column: 3/3;
+                }
             }
         }
         &--has-progress-slider {
@@ -482,12 +488,6 @@
 
         .result-icon {
             margin-left: 0.4rem;
-        }
-        &-mobile {
-            align-self: center;
-            justify-self: center;
-            grid-row: 1/3;
-            grid-column: 3/3;
         }
     }
     &__limit-order-info {

--- a/packages/components/src/components/contract-card/contract-card.scss
+++ b/packages/components/src/components/contract-card/contract-card.scss
@@ -288,6 +288,11 @@
             }
         }
     }
+    &-items-wrapper-mobile {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        grid-template-rows: auto;
+    }
     &__profit-loss {
         font-size: 1.2em;
         text-align: center;
@@ -459,10 +464,25 @@
             margin-left: 0.4rem;
         }
     }
+    &__status-mobile {
+        align-self: center;
+        justify-self: center;
+        grid-row: 1/3;
+        grid-column: 3/3;
+    }
     &__limit-order-info {
         grid-area: limit-order-info;
         display: grid;
         grid-gap: 0.4rem 0;
+        position: relative;
+
+        & .dc-contract-card__stop-loss {
+            padding-bottom: 0.4rem;
+        }
+    }
+    &__limit-order-info-mobile {
+        grid-row: 2/2;
+        grid-column: 2/2;
         position: relative;
 
         & .dc-contract-card__stop-loss {
@@ -477,6 +497,24 @@
     }
     &__stake {
         grid-area: stake;
+    }
+    &__stake-mobile {
+        grid-column: 1/1;
+        grid-row: 1/1;
+        padding: 8px 0;
+    }
+    &__current-price-mobile {
+        grid-column: 2/2;
+        grid-row: 1/2;
+        padding: 8px 0;
+    }
+    &__buy-price-mobile {
+        grid-column: 1/2;
+        grid-row: 2/2;
+    }
+    &__barrier-level-mobile {
+        grid-column: 2/2;
+        grid-row: 2/2;
     }
     &__date-expiry {
         grid-area: date-expiry;

--- a/packages/components/src/components/contract-card/contract-card.scss
+++ b/packages/components/src/components/contract-card/contract-card.scss
@@ -557,6 +557,15 @@
             color: var(--text-less-prominent);
         }
     }
+    &__type-turbos {
+        margin-left: 0.5rem;
+        line-height: 1.1;
+
+        &-subtype {
+            font-size: 1rem;
+            color: var(--text-less-prominent);
+        }
+    }
 }
 
 /** @define dc-btn; */

--- a/packages/components/src/components/contract-card/contract-card.scss
+++ b/packages/components/src/components/contract-card/contract-card.scss
@@ -551,21 +551,21 @@
         line-height: 1.5;
         text-align: left;
 
-        &-multiplier {
+        &-trade-param {
             font-size: 1rem;
             line-height: 1rem;
             color: var(--text-less-prominent);
         }
     }
-    &__type-turbos {
-        margin-left: 0.5rem;
-        line-height: 1.1;
+    // &__type-turbos {
+    //     margin-left: 0.5rem;
+    //     line-height: 1.1;
 
-        &-subtype {
-            font-size: 1rem;
-            color: var(--text-less-prominent);
-        }
-    }
+    //     &-subtype {
+    //         font-size: 1rem;
+    //         color: var(--text-less-prominent);
+    //     }
+    // }
 }
 
 /** @define dc-btn; */

--- a/packages/components/src/components/contract-card/contract-card.scss
+++ b/packages/components/src/components/contract-card/contract-card.scss
@@ -274,12 +274,12 @@
                 &__stake {
                     grid-column: 1/1;
                     grid-row: 1/1;
-                    padding: 8px 0;
+                    padding: 0.8rem 0;
                 }
                 &__current-price {
                     grid-column: 2/2;
                     grid-row: 1/2;
-                    padding: 8px 0;
+                    padding: 0.8rem 0;
                 }
                 &__buy-price {
                     grid-column: 1/2;

--- a/packages/components/src/components/contract-card/contract-card.scss
+++ b/packages/components/src/components/contract-card/contract-card.scss
@@ -288,11 +288,6 @@
             }
         }
     }
-    &-items-wrapper-mobile {
-        display: grid;
-        grid-template-columns: 1fr 1fr 1fr;
-        grid-template-rows: auto;
-    }
     &__profit-loss {
         font-size: 1.2em;
         text-align: center;
@@ -463,54 +458,49 @@
         .result-icon {
             margin-left: 0.4rem;
         }
-    }
-    &__status-mobile {
-        align-self: center;
-        justify-self: center;
-        grid-row: 1/3;
-        grid-column: 3/3;
+        &-mobile {
+            align-self: center;
+            justify-self: center;
+            grid-row: 1/3;
+            grid-column: 3/3;
+        }
     }
     &__limit-order-info {
         grid-area: limit-order-info;
         display: grid;
         grid-gap: 0.4rem 0;
         position: relative;
-
         & .dc-contract-card__stop-loss {
             padding-bottom: 0.4rem;
         }
-    }
-    &__limit-order-info-mobile {
-        grid-row: 2/2;
-        grid-column: 2/2;
-        position: relative;
-
-        & .dc-contract-card__stop-loss {
-            padding-bottom: 0.4rem;
+        &-mobile {
+            grid-row: 2/2;
+            grid-column: 2/2;
+            position: relative;
         }
     }
     &__buy-price {
         grid-area: buy-price;
+        &-mobile {
+            grid-column: 1/2;
+            grid-row: 2/2;
+        }
     }
     &__deal-cancel-fee {
         grid-area: deal-cancel-fee;
     }
     &__stake {
         grid-area: stake;
-    }
-    &__stake-mobile {
-        grid-column: 1/1;
-        grid-row: 1/1;
-        padding: 8px 0;
+        &-mobile {
+            grid-column: 1/1;
+            grid-row: 1/1;
+            padding: 8px 0;
+        }
     }
     &__current-price-mobile {
         grid-column: 2/2;
         grid-row: 1/2;
         padding: 8px 0;
-    }
-    &__buy-price-mobile {
-        grid-column: 1/2;
-        grid-row: 2/2;
     }
     &__barrier-level-mobile {
         grid-column: 2/2;
@@ -595,15 +585,6 @@
             color: var(--text-less-prominent);
         }
     }
-    // &__type-turbos {
-    //     margin-left: 0.5rem;
-    //     line-height: 1.1;
-
-    //     &-subtype {
-    //         font-size: 1rem;
-    //         color: var(--text-less-prominent);
-    //     }
-    // }
 }
 
 /** @define dc-btn; */

--- a/packages/components/src/components/contract-card/contract-card.scss
+++ b/packages/components/src/components/contract-card/contract-card.scss
@@ -270,6 +270,31 @@
             grid-gap: 0.8rem 0.4rem;
             flex: 1;
             padding: 0.4rem 0;
+            .dc-contract-card {
+                &__stake {
+                    grid-column: 1/1;
+                    grid-row: 1/1;
+                    padding: 8px 0;
+                }
+                &__current-price {
+                    grid-column: 2/2;
+                    grid-row: 1/2;
+                    padding: 8px 0;
+                }
+                &__buy-price {
+                    grid-column: 1/2;
+                    grid-row: 2/2;
+                }
+                &__barrier-level {
+                    grid-column: 2/2;
+                    grid-row: 2/2;
+                }
+                &__limit-order-info {
+                    grid-row: 2/2;
+                    grid-column: 2/2;
+                    position: relative;
+                }
+            }
         }
         &--has-progress-slider {
             grid-template-columns: 1fr 1fr 1fr;
@@ -473,38 +498,15 @@
         & .dc-contract-card__stop-loss {
             padding-bottom: 0.4rem;
         }
-        &-mobile {
-            grid-row: 2/2;
-            grid-column: 2/2;
-            position: relative;
-        }
     }
     &__buy-price {
         grid-area: buy-price;
-        &-mobile {
-            grid-column: 1/2;
-            grid-row: 2/2;
-        }
     }
     &__deal-cancel-fee {
         grid-area: deal-cancel-fee;
     }
     &__stake {
         grid-area: stake;
-        &-mobile {
-            grid-column: 1/1;
-            grid-row: 1/1;
-            padding: 8px 0;
-        }
-    }
-    &__current-price-mobile {
-        grid-column: 2/2;
-        grid-row: 1/2;
-        padding: 8px 0;
-    }
-    &__barrier-level-mobile {
-        grid-column: 2/2;
-        grid-row: 2/2;
     }
     &__date-expiry {
         grid-area: date-expiry;

--- a/packages/components/src/components/positions-drawer-card/positions-drawer-card.jsx
+++ b/packages/components/src/components/positions-drawer-card/positions-drawer-card.jsx
@@ -7,6 +7,7 @@ import {
     getContractPath,
     isCryptoContract,
     isMultiplierContract,
+    isTurbosContract,
     getCardLabels,
     getContractTypeDisplay,
     getEndTime,
@@ -43,9 +44,14 @@ const PositionsDrawerCard = ({
     toggleUnsupportedContractModal,
 }) => {
     const is_multiplier = isMultiplierContract(contract_info.contract_type);
+    const is_turbos = isTurbosContract(contract_info.contract_type);
     const is_crypto = isCryptoContract(contract_info.underlying);
     const has_progress_slider = !is_multiplier || (is_crypto && is_multiplier);
     const has_ended = !!getEndTime(contract_info);
+    const contract_card_classname = classNames('dc-contract-card', {
+        'dc-contract-card--green': !is_turbos && !is_multiplier && profit_loss > 0 && !result,
+        'dc-contract-card--red': !is_turbos && !is_multiplier && profit_loss < 0 && !result,
+    });
 
     const loader_el = (
         <div className='dc-contract-card__content-loader'>
@@ -61,7 +67,6 @@ const PositionsDrawerCard = ({
             getContractTypeDisplay={getContractTypeDisplay}
             has_progress_slider={!is_mobile && has_progress_slider}
             is_mobile={is_mobile}
-            is_positions={true}
             is_sell_requested={is_sell_requested}
             onClickSell={onClickSell}
             server_time={server_time}
@@ -82,7 +87,9 @@ const PositionsDrawerCard = ({
             }}
             is_mobile={is_mobile}
             is_multiplier={is_multiplier}
+            is_positions
             is_sold={has_ended}
+            is_turbos={is_turbos}
             has_progress_slider={is_mobile && has_progress_slider}
             removeToast={removeToast}
             server_time={server_time}
@@ -98,7 +105,7 @@ const PositionsDrawerCard = ({
             contract_info={contract_info}
             getCardLabels={getCardLabels}
             is_multiplier={is_multiplier}
-            is_positions={true}
+            is_positions
             is_sell_requested={is_sell_requested}
             onClickCancel={onClickCancel}
             onClickSell={onClickSell}
@@ -116,32 +123,16 @@ const PositionsDrawerCard = ({
     );
 
     const supported_contract_card = (
-        <div
-            className={classNames('dc-contract-card', {
-                'dc-contract-card--green': !is_multiplier && profit_loss > 0 && !result,
-                'dc-contract-card--red': !is_multiplier && profit_loss < 0 && !result,
-            })}
-            onClick={() => toggleUnsupportedContractModal(true)}
-        >
+        <div className={contract_card_classname} onClick={() => toggleUnsupportedContractModal(true)}>
             {contract_info.underlying ? contract_el : loader_el}
         </div>
     );
 
     const unsupported_contract_card = is_link_disabled ? (
-        <div
-            className={classNames('dc-contract-card', {
-                'dc-contract-card--green': !is_multiplier && profit_loss > 0 && !result,
-                'dc-contract-card--red': !is_multiplier && profit_loss < 0 && !result,
-            })}
-        >
-            {contract_info.underlying ? contract_el : loader_el}
-        </div>
+        <div className={contract_card_classname}>{contract_info.underlying ? contract_el : loader_el}</div>
     ) : (
         <NavLink
-            className={classNames('dc-contract-card', {
-                'dc-contract-card--green': !is_multiplier && profit_loss > 0 && !result,
-                'dc-contract-card--red': !is_multiplier && profit_loss < 0 && !result,
-            })}
+            className={contract_card_classname}
             to={{
                 pathname: `/contract/${contract_info.contract_id}`,
             }}
@@ -156,7 +147,8 @@ const PositionsDrawerCard = ({
             getCardLabels={getCardLabels}
             getContractPath={getContractPath}
             is_multiplier={is_multiplier}
-            is_positions={true}
+            is_positions
+            is_turbos={is_turbos}
             is_unsupported={is_unsupported}
             onClickRemove={onClickRemove}
             profit_loss={profit_loss}

--- a/packages/components/stories/contract-card/statics/contract.js
+++ b/packages/components/stories/contract-card/statics/contract.js
@@ -235,6 +235,14 @@ export const getSupportedContracts = is_high_low => ({
         name: 'Down',
         position: 'bottom',
     },
+    TURBOSLONG: {
+        name: 'Turbos',
+        position: 'top',
+    },
+    TURBOSSHORT: {
+        name: 'Turbos',
+        position: 'bottom',
+    },
 });
 
 export const getContractConfig = is_high_low => ({

--- a/packages/components/stories/contract-card/statics/contract.js
+++ b/packages/components/stories/contract-card/statics/contract.js
@@ -2,10 +2,12 @@ import { localize } from '@deriv/translations';
 
 export const getCardLabels = () => ({
     APPLY: 'Apply',
+    BARRIER_LEVEL: 'Barrier level',
     STAKE: 'Stake:',
     CLOSE: 'Close',
     CANCEL: 'Cancel',
     CURRENT_STAKE: 'Current stake:',
+    CURRENT_PRICE: 'Current price',
     DEAL_CANCEL_FEE: 'Deal cancel. fee:',
     TAKE_PROFIT: 'Take profit:',
     BUY_PRICE: 'Buy price:',

--- a/packages/reports/src/_common/contract.js
+++ b/packages/reports/src/_common/contract.js
@@ -3,10 +3,12 @@ import { localize, Localize } from '@deriv/translations';
 
 export const getCardLabels = () => ({
     APPLY: localize('Apply'),
+    BARRIER_LEVEL: localize('Barrier level'),
     STAKE: localize('Stake:'),
     CLOSE: localize('Close'),
     CANCEL: localize('Cancel'),
     CURRENT_STAKE: localize('Current stake:'),
+    CURRENT_PRICE: localize('Current price'),
     DEAL_CANCEL_FEE: localize('Deal cancel. fee:'),
     TAKE_PROFIT: localize('Take profit:'),
     BUY_PRICE: localize('Buy price:'),

--- a/packages/shared/src/utils/constants/contract.tsx
+++ b/packages/shared/src/utils/constants/contract.tsx
@@ -181,10 +181,12 @@ export const unsupported_contract_types_list = [
 
 export const getCardLabels = () => ({
     APPLY: localize('Apply'),
+    BARRIER_LEVEL: localize('Barrier level'),
     STAKE: localize('Stake:'),
     CLOSE: localize('Close'),
     CANCEL: localize('Cancel'),
     CURRENT_STAKE: localize('Current stake:'),
+    CURRENT_PRICE: localize('Current price'),
     DEAL_CANCEL_FEE: localize('Deal cancel. fee:'),
     TAKE_PROFIT: localize('Take profit:'),
     BUY_PRICE: localize('Buy price:'),

--- a/packages/shared/src/utils/constants/contract.tsx
+++ b/packages/shared/src/utils/constants/contract.tsx
@@ -438,7 +438,7 @@ export const getSupportedContracts = (is_high_low?: boolean) => ({
         position: 'bottom',
     },
     TURBOSLONG: {
-        name: <Localize i18n_default_text='Tubos' />,
+        name: <Localize i18n_default_text='Turbos' />,
         button_name: <Localize i18n_default_text='Buy' />,
         position: 'top',
     },

--- a/packages/shared/src/utils/constants/contract.tsx
+++ b/packages/shared/src/utils/constants/contract.tsx
@@ -24,6 +24,14 @@ type TContractTypesConfig = {
 
 type TGetContractTypesConfig = (symbol: string) => Record<string, TContractTypesConfig>;
 
+type TContractConfig = {
+    button_name?: React.ReactNode;
+    name: React.ReactNode;
+    position: string;
+};
+
+type TGetSupportedContracts = keyof ReturnType<typeof getSupportedContracts>;
+
 export const getContractTypesConfig: TGetContractTypesConfig = symbol => ({
     rise_fall: {
         title: localize('Rise/Fall'),
@@ -370,7 +378,6 @@ export const getUnsupportedContracts = () => ({
     },
 });
 
-type TGetSupportedContracts = keyof ReturnType<typeof getSupportedContracts>;
 export const getSupportedContracts = (is_high_low?: boolean) => ({
     CALL: {
         name: is_high_low ? <Localize i18n_default_text='Higher' /> : <Localize i18n_default_text='Rise' />,
@@ -429,11 +436,13 @@ export const getSupportedContracts = (is_high_low?: boolean) => ({
         position: 'bottom',
     },
     TURBOSLONG: {
-        name: <Localize i18n_default_text='Buy' />,
+        name: <Localize i18n_default_text='Tubos' />,
+        button_name: <Localize i18n_default_text='Buy' />,
         position: 'top',
     },
     TURBOSSHORT: {
-        name: <Localize i18n_default_text='Buy' />,
+        name: <Localize i18n_default_text='Turbos' />,
+        button_name: <Localize i18n_default_text='Buy' />,
         position: 'bottom',
     },
 });
@@ -447,8 +456,12 @@ export const getContractConfig = (is_high_low?: boolean) => ({
 // TODO we can combine getContractTypeDisplay and getContractTypePosition functions.
 the difference between these two functions is just the property they return. (name/position)
 */
-export const getContractTypeDisplay = (type: TGetSupportedContracts, is_high_low = false) =>
-    getContractConfig(is_high_low)[type].name;
+
+export const getContractTypeDisplay = (type: TGetSupportedContracts, is_high_low = false, show_trade_text = false) => {
+    return show_trade_text
+        ? (getContractConfig(is_high_low)[type] as TContractConfig).button_name
+        : getContractConfig(is_high_low)[type].name;
+};
 
 export const getContractTypePosition = (type: TGetSupportedContracts, is_high_low = false) =>
     getContractConfig(is_high_low)[type].position || 'top';

--- a/packages/shared/src/utils/contract/contract.ts
+++ b/packages/shared/src/utils/contract/contract.ts
@@ -154,3 +154,9 @@ export const getContractUpdateConfig = ({ contract_update, limit_order }: TGetCo
 export const shouldShowExpiration = (symbol: string) => /^cry/.test(symbol);
 
 export const shouldShowCancellation = (symbol: string) => !/^(cry|CRASH|BOOM|stpRNG|WLD|JD)/.test(symbol);
+
+export const getSubType = (type: string) => {
+    const sub_type: string[] = type.toLowerCase().replace('turbos', '').split('');
+    sub_type[0] = sub_type[0].toUpperCase();
+    return `${sub_type.join('')}`;
+};

--- a/packages/shared/src/utils/contract/contract.ts
+++ b/packages/shared/src/utils/contract/contract.ts
@@ -156,7 +156,7 @@ export const shouldShowExpiration = (symbol: string) => /^cry/.test(symbol);
 export const shouldShowCancellation = (symbol: string) => !/^(cry|CRASH|BOOM|stpRNG|WLD|JD)/.test(symbol);
 
 export const getSubType = (type: string) => {
-    const sub_type: string[] = type.toLowerCase().replace('turbos', '').split('');
-    sub_type[0] = sub_type[0].toUpperCase();
-    return `${sub_type.join('')}`;
+    const subtype: string[] = type.toLowerCase().replace('turbos', '').split('');
+    subtype[0] = subtype[0].toUpperCase();
+    return `${subtype.join('')}`;
 };

--- a/packages/trader/src/App/Components/Elements/ContractAudit/contract-audit.jsx
+++ b/packages/trader/src/App/Components/Elements/ContractAudit/contract-audit.jsx
@@ -6,7 +6,14 @@ import { WS } from '@deriv/shared';
 import ContractDetails from './contract-details.jsx';
 import ContractHistory from './contract-history.jsx';
 
-const ContractAudit = ({ contract_update_history, has_result, is_multiplier, toggleHistoryTab, ...props }) => {
+const ContractAudit = ({
+    contract_update_history,
+    has_result,
+    is_multiplier,
+    is_turbos,
+    toggleHistoryTab,
+    ...props
+}) => {
     const { contract_id, currency } = props.contract_info;
     const [update_history, setUpdateHistory] = React.useState([]);
 
@@ -28,7 +35,7 @@ const ContractAudit = ({ contract_update_history, has_result, is_multiplier, tog
 
     if (!has_result) return null;
 
-    if (!is_multiplier) {
+    if (!is_multiplier && !is_turbos) {
         return (
             <div className='contract-audit__wrapper'>
                 <ContractDetails {...props} />
@@ -54,6 +61,7 @@ ContractAudit.propTypes = {
     contract_update_history: PropTypes.array,
     has_result: PropTypes.bool,
     is_multiplier: PropTypes.bool,
+    is_turbos: PropTypes.bool,
     toggleHistoryTab: PropTypes.func,
 };
 

--- a/packages/trader/src/App/Components/Elements/ContractAudit/contract-details.jsx
+++ b/packages/trader/src/App/Components/Elements/ContractAudit/contract-details.jsx
@@ -8,6 +8,7 @@ import {
     getCancellationPrice,
     isMobile,
     isMultiplierContract,
+    isTurbosContract,
     isUserSold,
     isEndedBeforeCancellationExpired,
     isUserCancelled,
@@ -47,6 +48,62 @@ const ContractDetails = ({ contract_end_time, contract_info, duration, duration_
         return localize('Deal cancellation (active)');
     };
 
+    const barrier_card_info = (
+        <ContractAuditItem
+            id='dt_bt_label'
+            icon={
+                isDigitType(contract_type) ? (
+                    <Icon icon='IcContractTarget' size={24} />
+                ) : (
+                    <Icon icon='IcContractBarrier' size={24} />
+                )
+            }
+            label={getBarrierLabel(contract_info)}
+            value={getBarrierValue(contract_info) || ' - '}
+        />
+    );
+
+    let unic_card_info;
+
+    if (isMultiplierContract(contract_type)) {
+        unic_card_info = (
+            <React.Fragment>
+                <ContractAuditItem
+                    id='dt_commission_label'
+                    icon={<Icon icon='IcContractCommission' size={24} />}
+                    label={localize('Commission')}
+                    value={<Money amount={commission} currency={currency} show_currency />}
+                />
+                {!!cancellation_price && (
+                    <ContractAuditItem
+                        id='dt_cancellation_label'
+                        icon={<Icon icon='IcContractSafeguard' size={24} />}
+                        label={getLabel()}
+                        value={<Money amount={cancellation_price} currency={currency} />}
+                    />
+                )}
+            </React.Fragment>
+        );
+    } else if (isTurbosContract(contract_type)) {
+        unic_card_info = isNaN(contract_end_time) ? null : (
+            <React.Fragment>
+                <ContractAuditItem
+                    id='dt_duration_label'
+                    icon={<Icon icon='IcContractDuration' size={24} />}
+                    label={localize('Duration')}
+                    value={
+                        tick_count > 0
+                            ? `${tick_count} ${tick_count < 2 ? localize('tick') : localize('ticks')}`
+                            : `${duration} ${duration_unit}`
+                    }
+                />
+                {barrier_card_info}
+            </React.Fragment>
+        );
+    } else {
+        unic_card_info = barrier_card_info;
+    }
+
     return (
         <ThemedScrollbars is_bypassed={isMobile()}>
             <div className='contract-audit__tabs-content'>
@@ -57,49 +114,7 @@ const ContractDetails = ({ contract_end_time, contract_info, duration, duration_
                     value={localize('{{buy_value}} (Buy)', { buy_value: buy })}
                     value2={sell ? localize('{{sell_value}} (Sell)', { sell_value: sell }) : undefined}
                 />
-                {isMultiplierContract(contract_type) ? (
-                    <React.Fragment>
-                        <ContractAuditItem
-                            id='dt_commission_label'
-                            icon={<Icon icon='IcContractCommission' size={24} />}
-                            label={localize('Commission')}
-                            value={<Money amount={commission} currency={currency} show_currency />}
-                        />
-                        {!!cancellation_price && (
-                            <ContractAuditItem
-                                id='dt_cancellation_label'
-                                icon={<Icon icon='IcContractSafeguard' size={24} />}
-                                label={getLabel()}
-                                value={<Money amount={cancellation_price} currency={currency} />}
-                            />
-                        )}
-                    </React.Fragment>
-                ) : (
-                    <React.Fragment>
-                        <ContractAuditItem
-                            id='dt_duration_label'
-                            icon={<Icon icon='IcContractDuration' size={24} />}
-                            label={localize('Duration')}
-                            value={
-                                tick_count > 0
-                                    ? `${tick_count} ${tick_count < 2 ? localize('tick') : localize('ticks')}`
-                                    : `${duration} ${duration_unit}`
-                            }
-                        />
-                        <ContractAuditItem
-                            id='dt_bt_label'
-                            icon={
-                                isDigitType(contract_type) ? (
-                                    <Icon icon='IcContractTarget' size={24} />
-                                ) : (
-                                    <Icon icon='IcContractBarrier' size={24} />
-                                )
-                            }
-                            label={getBarrierLabel(contract_info)}
-                            value={getBarrierValue(contract_info) || ' - '}
-                        />
-                    </React.Fragment>
-                )}
+                {unic_card_info}
                 <ContractAuditItem
                     id='dt_start_time_label'
                     icon={<Icon icon='IcContractStartTime' size={24} />}

--- a/packages/trader/src/App/Components/Elements/ContractAudit/contract-details.jsx
+++ b/packages/trader/src/App/Components/Elements/ContractAudit/contract-details.jsx
@@ -63,10 +63,10 @@ const ContractDetails = ({ contract_end_time, contract_info, duration, duration_
         />
     );
 
-    let unic_card_info;
+    let unique_card_info;
 
     if (isMultiplierContract(contract_type)) {
-        unic_card_info = (
+        unique_card_info = (
             <React.Fragment>
                 <ContractAuditItem
                     id='dt_commission_label'
@@ -85,7 +85,7 @@ const ContractDetails = ({ contract_end_time, contract_info, duration, duration_
             </React.Fragment>
         );
     } else if (isTurbosContract(contract_type)) {
-        unic_card_info = isNaN(contract_end_time) ? null : (
+        unique_card_info = isNaN(contract_end_time) ? null : (
             <React.Fragment>
                 <ContractAuditItem
                     id='dt_duration_label'
@@ -101,7 +101,7 @@ const ContractDetails = ({ contract_end_time, contract_info, duration, duration_
             </React.Fragment>
         );
     } else {
-        unic_card_info = barrier_card_info;
+        unique_card_info = barrier_card_info;
     }
 
     return (
@@ -114,7 +114,7 @@ const ContractDetails = ({ contract_end_time, contract_info, duration, duration_
                     value={localize('{{buy_value}} (Buy)', { buy_value: buy })}
                     value2={sell ? localize('{{sell_value}} (Sell)', { sell_value: sell }) : undefined}
                 />
-                {unic_card_info}
+                {unique_card_info}
                 <ContractAuditItem
                     id='dt_start_time_label'
                     icon={<Icon icon='IcContractStartTime' size={24} />}

--- a/packages/trader/src/App/Components/Elements/ContractDrawer/contract-drawer-card.jsx
+++ b/packages/trader/src/App/Components/Elements/ContractDrawer/contract-drawer-card.jsx
@@ -23,6 +23,7 @@ const ContractDrawerCard = ({
     is_multiplier,
     is_sell_requested,
     is_collapsed,
+    is_turbos,
     onClickCancel,
     onClickSell,
     onSwipedUp,
@@ -72,6 +73,7 @@ const ContractDrawerCard = ({
             getContractById={getContractById}
             is_mobile={is_mobile}
             is_multiplier={is_multiplier}
+            is_turbos={is_turbos}
             is_sold={is_sold}
             removeToast={removeToast}
             server_time={server_time}
@@ -163,6 +165,7 @@ ContractDrawerCard.propTypes = {
     is_market_closed: PropTypes.bool,
     is_mobile: PropTypes.bool,
     is_multiplier: PropTypes.bool,
+    is_turbos: PropTypes.bool,
     is_sell_requested: PropTypes.bool,
     onClickCancel: PropTypes.func,
     onClickSell: PropTypes.func,

--- a/packages/trader/src/App/Components/Elements/ContractDrawer/contract-drawer-card.jsx
+++ b/packages/trader/src/App/Components/Elements/ContractDrawer/contract-drawer-card.jsx
@@ -135,15 +135,17 @@ const ContractDrawerCard = ({
         </ContractCard>
     );
 
+    const has_swipeable_drawer = is_sold || is_multiplier || is_turbos;
+
     return (
         <React.Fragment>
             <DesktopWrapper>{contract_card}</DesktopWrapper>
             <MobileWrapper>
                 <SwipeableContractDrawer
-                    onSwipedUp={is_sold || is_multiplier ? onSwipedUp : undefined}
-                    onSwipedDown={is_sold || is_multiplier ? onSwipedDown : undefined}
+                    onSwipedUp={has_swipeable_drawer ? onSwipedUp : undefined}
+                    onSwipedDown={has_swipeable_drawer ? onSwipedDown : undefined}
                 >
-                    {(is_sold || is_multiplier) && (
+                    {has_swipeable_drawer && (
                         <Collapsible.ArrowButton onClick={toggleContractAuditDrawer} is_collapsed={is_collapsed} />
                     )}
                     {contract_card}

--- a/packages/trader/src/App/Components/Elements/ContractDrawer/contract-drawer.jsx
+++ b/packages/trader/src/App/Components/Elements/ContractDrawer/contract-drawer.jsx
@@ -27,6 +27,7 @@ const ContractDrawer = ({
     is_dark_theme,
     is_market_closed,
     is_multiplier,
+    is_turbos,
     onClickCancel,
     onClickSell,
     server_time,
@@ -39,7 +40,7 @@ const ContractDrawer = ({
     const [should_show_contract_audit, setShouldShowContractAudit] = React.useState(false);
 
     const getBodyContent = () => {
-        const exit_spot = isUserSold(contract_info) && !is_multiplier ? '-' : exit_tick_display_value;
+        const exit_spot = isUserSold(contract_info) && !is_multiplier && !is_turbos ? '-' : exit_tick_display_value;
 
         const contract_audit = (
             <ContractAudit
@@ -48,11 +49,12 @@ const ContractDrawer = ({
                 contract_end_time={getEndTime(contract_info)}
                 is_dark_theme={is_dark_theme}
                 is_multiplier={is_multiplier}
+                is_turbos={is_turbos}
                 is_open
                 duration={getDurationTime(contract_info)}
                 duration_unit={getDurationUnitText(getDurationPeriod(contract_info))}
                 exit_spot={exit_spot}
-                has_result={!!is_sold || is_multiplier}
+                has_result={!!is_sold || is_multiplier || is_turbos}
                 toggleHistoryTab={toggleHistoryTab}
             />
         );
@@ -66,6 +68,7 @@ const ContractDrawer = ({
                     is_mobile={is_mobile}
                     is_market_closed={is_market_closed}
                     is_multiplier={is_multiplier}
+                    is_turbos={is_turbos}
                     is_sell_requested={is_sell_requested}
                     is_collapsed={should_show_contract_audit}
                     onClickCancel={onClickCancel}
@@ -86,7 +89,7 @@ const ContractDrawer = ({
     // For non-binary contract, the status is always null, so we check for is_expired in contract_info
     const fallback_result = contract_info.status || contract_info.is_expired;
 
-    const exit_spot = isUserSold(contract_info) && !is_multiplier ? '-' : exit_tick_display_value;
+    const exit_spot = isUserSold(contract_info) && !is_multiplier && !is_turbos ? '-' : exit_tick_display_value;
 
     const contract_audit = (
         <ContractAudit
@@ -95,11 +98,12 @@ const ContractDrawer = ({
             contract_end_time={getEndTime(contract_info)}
             is_dark_theme={is_dark_theme}
             is_multiplier={is_multiplier}
+            is_turbos={is_turbos}
             is_open
             duration={getDurationTime(contract_info)}
             duration_unit={getDurationUnitText(getDurationPeriod(contract_info))}
             exit_spot={exit_spot}
-            has_result={!!is_sold || is_multiplier}
+            has_result={!!is_sold || is_multiplier || is_turbos}
             toggleHistoryTab={toggleHistoryTab}
         />
     );
@@ -118,7 +122,7 @@ const ContractDrawer = ({
                 id='dt_contract_drawer'
                 className={classNames('contract-drawer', {
                     'contract-drawer--with-collapsible-btn':
-                        !!getEndTime(contract_info) || (is_multiplier && isMobile()),
+                        !!getEndTime(contract_info) || ((is_multiplier || is_turbos) && isMobile()),
                     'contract-drawer--is-multiplier': is_multiplier && isMobile(),
                     'contract-drawer--is-multiplier-sold': is_multiplier && isMobile() && getEndTime(contract_info),
                 })}
@@ -174,6 +178,7 @@ ContractDrawer.propTypes = {
     is_market_closed: PropTypes.bool,
     is_mobile: PropTypes.bool,
     is_multiplier: PropTypes.bool,
+    is_turbos: PropTypes.bool,
     is_history_tab_active: PropTypes.bool,
     is_sell_requested: PropTypes.bool,
     onClickCancel: PropTypes.func,

--- a/packages/trader/src/App/Components/Elements/PositionsDrawer/positions-modal-card.jsx
+++ b/packages/trader/src/App/Components/Elements/PositionsDrawer/positions-modal-card.jsx
@@ -7,6 +7,7 @@ import {
     getContractPath,
     isCryptoContract,
     isMultiplierContract,
+    isTurbosContract,
     isHighLow,
     isCryptocurrency,
     hasContractEntered,
@@ -60,6 +61,7 @@ const PositionsModalCard = ({
         </div>
     );
     const is_multiplier = isMultiplierContract(contract_info.contract_type);
+    const is_turbos = isTurbosContract(contract_info.contract_type);
     const is_crypto = isCryptoContract(contract_info.underlying);
     const has_progress_slider = !is_multiplier || (is_crypto && is_multiplier);
     const has_ended = !!getEndTime(contract_info);
@@ -201,13 +203,13 @@ const PositionsModalCard = ({
         </React.Fragment>
     );
 
-    const card_multiplier_header = (
+    const custom_card_header = (
         <ContractCard.Header
             contract_info={contract_info}
             display_name={display_name}
             getCardLabels={getCardLabels}
             getContractTypeDisplay={getContractTypeDisplay}
-            has_progress_slider={!is_mobile && has_progress_slider}
+            has_progress_slider={(!is_mobile && has_progress_slider) || is_turbos}
             is_mobile={is_mobile}
             is_sell_requested={is_sell_requested}
             onClickSell={onClickSell}
@@ -215,7 +217,7 @@ const PositionsModalCard = ({
         />
     );
 
-    const card_multiplier_body = (
+    const custom_card_body = (
         <ContractCard.Body
             addToast={addToast}
             connectWithContractUpdate={connectWithContractUpdate}
@@ -227,6 +229,9 @@ const PositionsModalCard = ({
             getContractById={getContractById}
             is_mobile={is_mobile}
             is_multiplier={is_multiplier}
+            is_turbos={is_turbos}
+            is_positions
+            is_sold={!!contract_info.is_sold}
             has_progress_slider={is_mobile && has_progress_slider && !has_ended}
             removeToast={removeToast}
             server_time={server_time}
@@ -237,7 +242,7 @@ const PositionsModalCard = ({
         />
     );
 
-    const card_multiplier_footer = (
+    const custom_card_footer = (
         <ContractCard.Footer
             contract_info={contract_info}
             getCardLabels={getCardLabels}
@@ -250,7 +255,7 @@ const PositionsModalCard = ({
         />
     );
 
-    const contract_multiplier_el = (
+    const custom_contract_el = (
         <React.Fragment>
             <ContractCard
                 contract_info={contract_info}
@@ -259,14 +264,14 @@ const PositionsModalCard = ({
                 profit_loss={profit_loss}
                 should_show_result_overlay={false}
             >
-                {card_multiplier_header}
-                {card_multiplier_body}
-                {card_multiplier_footer}
+                {custom_card_header}
+                {custom_card_body}
+                {custom_card_footer}
             </ContractCard>
         </React.Fragment>
     );
 
-    const contract_el = is_multiplier ? contract_multiplier_el : contract_options_el;
+    const contract_el = is_multiplier || is_turbos ? custom_contract_el : contract_options_el;
 
     return (
         <div id={`dt_drawer_card_${id}`} className={classNames('positions-modal-card__wrapper', className)}>

--- a/packages/trader/src/Constants/contract.js
+++ b/packages/trader/src/Constants/contract.js
@@ -3,10 +3,12 @@ import { localize, Localize } from '@deriv/translations';
 
 export const getCardLabels = () => ({
     APPLY: localize('Apply'),
+    BARRIER_LEVEL: localize('Barrier level'),
     STAKE: localize('Stake:'),
     CLOSE: localize('Close'),
     CANCEL: localize('Cancel'),
     CURRENT_STAKE: localize('Current stake:'),
+    CURRENT_PRICE: localize('Current price'),
     DEAL_CANCEL_FEE: localize('Deal cancel. fee:'),
     TAKE_PROFIT: localize('Take profit:'),
     BUY_PRICE: localize('Buy price:'),

--- a/packages/trader/src/Constants/contract.js
+++ b/packages/trader/src/Constants/contract.js
@@ -258,11 +258,13 @@ export const getSupportedContracts = is_high_low => ({
         position: 'bottom',
     },
     TURBOSLONG: {
-        name: <Localize i18n_default_text='Buy' />,
+        button_name: <Localize i18n_default_text='Buy' />,
+        name: <Localize i18n_default_text='Turbos' />,
         position: 'top',
     },
     TURBOSSHORT: {
-        name: <Localize i18n_default_text='Buy' />,
+        button_name: <Localize i18n_default_text='Buy' />,
+        name: <Localize i18n_default_text='Turbos' />,
         position: 'bottom',
     },
 });
@@ -272,8 +274,9 @@ export const getContractConfig = is_high_low => ({
     ...getUnsupportedContracts(),
 });
 
-export const getContractTypeDisplay = (type, is_high_low = false) => {
-    return getContractConfig(is_high_low)[type] ? getContractConfig(is_high_low)[type.toUpperCase()].name : '';
+export const getContractTypeDisplay = (type, is_high_low = false, show_trade_text = false) => {
+    const contract_config = getContractConfig(is_high_low)[type];
+    return show_trade_text ? contract_config.button_name || contract_config.name : contract_config.name;
 };
 
 export const getContractTypePosition = (type, is_high_low = false) =>

--- a/packages/trader/src/Modules/Contract/Containers/contract-replay.jsx
+++ b/packages/trader/src/Modules/Contract/Containers/contract-replay.jsx
@@ -14,6 +14,7 @@ import {
     isDesktop,
     isMobile,
     isMultiplierContract,
+    isTurbosContract,
     isEmptyObject,
     getPlatformRedirect,
     urlFor,
@@ -74,6 +75,7 @@ const ContractReplay = ({
     if (!contract_info.underlying) return null;
 
     const is_multiplier = isMultiplierContract(contract_info.contract_type);
+    const is_turbos = isTurbosContract(contract_info.contract_type);
 
     const contract_drawer_el = (
         <ContractDrawer
@@ -84,6 +86,7 @@ const ContractReplay = ({
             is_dark_theme={is_dark_theme}
             is_market_closed={is_market_closed}
             is_multiplier={is_multiplier}
+            is_turbos={is_turbos}
             is_sell_requested={is_sell_requested}
             is_valid_to_cancel={is_valid_to_cancel}
             onClickCancel={onClickCancel}

--- a/packages/trader/src/Modules/Trading/Components/Elements/purchase-button.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Elements/purchase-button.jsx
@@ -10,9 +10,7 @@ const ButtonTextWrapper = ({ should_fade, is_loading, type, is_high_low }) => {
     return (
         <div className='btn-purchase__text_wrapper'>
             <Text size='xs' weight='bold' color='colored-background'>
-                {!should_fade && is_loading
-                    ? ''
-                    : getContractTypeDisplay(type, is_high_low, true) || getContractTypeDisplay(type, is_high_low)}
+                {!should_fade && is_loading ? '' : getContractTypeDisplay(type, is_high_low, true)}
             </Text>
         </div>
     );

--- a/packages/trader/src/Modules/Trading/Components/Elements/purchase-button.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Elements/purchase-button.jsx
@@ -10,7 +10,9 @@ const ButtonTextWrapper = ({ should_fade, is_loading, type, is_high_low }) => {
     return (
         <div className='btn-purchase__text_wrapper'>
             <Text size='xs' weight='bold' color='colored-background'>
-                {!should_fade && is_loading ? '' : getContractTypeDisplay(type, is_high_low)}
+                {!should_fade && is_loading
+                    ? ''
+                    : getContractTypeDisplay(type, is_high_low, true) || getContractTypeDisplay(type, is_high_low)}
             </Text>
         </div>
     );

--- a/packages/trader/src/Stores/Modules/Trading/Helpers/proposal.js
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/proposal.js
@@ -44,6 +44,8 @@ export const getProposalInfo = (store, response, obj_prev_contract_basis) => {
     const turbos_details = {
         barrier_choices: proposal.barrier_choices || response?.error?.details?.barrier_choices,
         number_of_contracts: proposal.number_of_contracts,
+        max_stake: proposal.max_stake,
+        min_stake: proposal.min_stake,
     };
 
     return {

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.js
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.js
@@ -135,9 +135,8 @@ export default class TradeStore extends BaseStore {
     // Turbos trade params
     number_of_contracts = 0;
     turbos_barrier_choices = [];
-    //TODO: clean up min_stake ans max_stake after BE will be ready
-    min_stake = 1;
-    max_stake = 100;
+    min_stake = 0;
+    max_stake = 0;
 
     // Mobile
     is_trade_params_expanded = true;
@@ -215,6 +214,8 @@ export default class TradeStore extends BaseStore {
             barrier_1: observable,
             barrier_2: observable,
             barrier_count: observable,
+            min_stake: observable,
+            max_stake: observable,
             main_barrier: observable,
             barriers: observable,
             start_date: observable,
@@ -1053,9 +1054,12 @@ export default class TradeStore extends BaseStore {
         if (this.is_turbos && this.proposal_info) {
             const contract_key = this.contract_type.toUpperCase();
             if (this.proposal_info[contract_key]) {
-                const { barrier_choices, number_of_contracts } = this.proposal_info[contract_key];
+                const { barrier_choices, number_of_contracts, max_stake, min_stake } = this.proposal_info[contract_key];
+
                 this.turbos_barrier_choices = barrier_choices || [];
                 this.number_of_contracts = number_of_contracts ?? 0;
+                this.max_stake = max_stake ?? 0;
+                this.min_stake = min_stake ?? 0;
                 if (barrier_choices && !barrier_choices.includes(this.barrier_1)) {
                     this.onChange({
                         target: {


### PR DESCRIPTION
## Changes:

### For Recent Positions:
- Add card for turbos contract in recent positions (for desktop and mobile).
- Refactored function `getContractTypeDisplay`: add check for the existence of `button_name` key, because for Turbos text on the purchase button is different from the text on recent position card (top right corner). If  `button_name` don't exist (like for majority of contact types) function returns value under `name` key.
- According to the design, in the top right corner of Turbos Contract card in Recent Positions drawer we should show 'Turbos Short' or 'Turbos Long', written in 2 lines. So, if the type is `TURBOSLONG` or `TURBOSSHORT` we call new implemented function `getSubType`, which returns a prettier version ('Short' or 'Long'). Of course we may also check the type with the help of `switch case` but it'll look to cumbersome. 
- Check of the trade type in `contract-type-cell.jsx ` was lifted up to the parent component (`contract-card-header.jsx`). There we run thought `contract_type_list_info`, looking for text to current trade type and pass it down to child component. `contract_type_list_info` is an array with objects and this organisation allow us to add new trade types even with very specific text in future. 
- Removed `MultiplierCardBody` from `contract-card-body.jsx` to a separate file in order to decomposing.

### For Contract Details:
- Add turbos contract card to contract details page (for desktop and mobile).

### Extra:
- Delete hardcoded max_stake and min_stake and set them in `onProposalResponse`.

## TODO/Problems:

- For existing barrier contracts we expect `proposal_open _contract` to contain `tick_stream` for ongoing tick duration contract and `audit_details` (with all contract ticks inside) additionally for the closed tick duration contract.
But the structure of `proposal_open_contract` API response for Turbos is different (as `tick_stream` was removed), so we need a clarification from BE. This affect counter appearance (because it's different for ticks and minutes) and text in `duration` in contract details card.
[Thread discussion](https://deriv-group.slack.com/archives/C04KNGWT4SY/p1676022318278919)
- We get `status: null` in `proposal_open_contract`. That is why for contracts, which user win we may show 'lost'. Need a clarification from BE.
[Thread discussion](https://deriv-group.slack.com/archives/C04KNGWT4SY/p1676046535552309)
- History tab on card in Contracts Details page is temporary empty (even if the user add `Take profit`). The reason might be that we get an empty array `contract_update_history` in response. Need a clarification from BE.
[Thread discussion](https://deriv-group.slack.com/archives/C04KNGWT4SY/p1676299484444599)
- Props drilling can be improved. We pass props (`is_turbos` for e.g.) from `ContractReplay` -> `ContractDrawer` -> `ContractDrawerCard` -> `ContractCardBody` and etc. 

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behaviour for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
