### PR TITLE
Kate/87523/Make barriers and payout per point collapsible in responsive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@contentpass/zxcvbn": "^4.4.3",
                 "@deriv/api-types": "^1.0.11",
                 "@deriv/deriv-api": "^1.0.11",
-                "@deriv/deriv-charts": "1.1.6",
+                "@deriv/deriv-charts": "1.1.7",
                 "@deriv/js-interpreter": "^3.0.0",
                 "@deriv/ui": "^0.0.15",
                 "@enykeev/react-virtualized": "^9.22.4-mirror.1",
@@ -2810,9 +2810,9 @@
             "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/@deriv/deriv-charts": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-1.1.6.tgz",
-            "integrity": "sha512-O3mzhzehIk48eeaRwn5LODSUwBqGD2J6EN7x0es+PtBcPSIS5QhPS4I3ke6730fLebB7mk7UPBtGTKR3WKR8ww==",
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-1.1.7.tgz",
+            "integrity": "sha512-3pkrrNNuiCPS0T89d97cJuTYmHv7WkorD78GbOUU8gdet01XR04tWTwQX+HHeZ/t6iumk5uFRWYK3XSHZgJHEw==",
             "dependencies": {
                 "@welldone-software/why-did-you-render": "^3.3.8",
                 "classnames": "^2.3.1",
@@ -49118,9 +49118,9 @@
             }
         },
         "@deriv/deriv-charts": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-1.1.6.tgz",
-            "integrity": "sha512-O3mzhzehIk48eeaRwn5LODSUwBqGD2J6EN7x0es+PtBcPSIS5QhPS4I3ke6730fLebB7mk7UPBtGTKR3WKR8ww==",
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@deriv/deriv-charts/-/deriv-charts-1.1.7.tgz",
+            "integrity": "sha512-3pkrrNNuiCPS0T89d97cJuTYmHv7WkorD78GbOUU8gdet01XR04tWTwQX+HHeZ/t6iumk5uFRWYK3XSHZgJHEw==",
             "requires": {
                 "@welldone-software/why-did-you-render": "^3.3.8",
                 "classnames": "^2.3.1",

--- a/packages/bot-web-ui/package.json
+++ b/packages/bot-web-ui/package.json
@@ -66,7 +66,7 @@
     "dependencies": {
         "@deriv/bot-skeleton": "^1.0.0",
         "@deriv/components": "^1.0.0",
-        "@deriv/deriv-charts": "1.1.6",
+        "@deriv/deriv-charts": "1.1.7",
         "@deriv/shared": "^1.0.0",
         "@deriv/translations": "^1.0.0",
         "classnames": "^2.2.6",

--- a/packages/components/src/components/contract-card/contract-card-items/contract-card-header.jsx
+++ b/packages/components/src/components/contract-card/contract-card-items/contract-card-header.jsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { CSSTransition } from 'react-transition-group';
-import { isHighLow, getCurrentTick, isBot, getSubType, isTurbosContract } from '@deriv/shared';
+import { isHighLow, getCurrentTick, isBot, getTurbosSubtype, isTurbosContract } from '@deriv/shared';
 import ContractTypeCell from './contract-type-cell.jsx';
 import Button from '../../button';
 import Icon from '../../icon';
@@ -38,7 +38,7 @@ const ContractCardHeader = ({
         },
         {
             is_param_displayed: isTurbosContract(contract_type),
-            displayed_param: getSubType(contract_type),
+            displayed_param: getTurbosSubtype(contract_type),
         },
     ];
 

--- a/packages/components/src/components/div100vh-container/div100vh-container.tsx
+++ b/packages/components/src/components/div100vh-container/div100vh-container.tsx
@@ -38,6 +38,11 @@ const Div100vhContainer = ({
         height: max_autoheight_offset ? '' : height_rule,
         maxHeight: max_autoheight_offset ? `calc(100rvh - ${max_autoheight_offset})` : '',
     };
+    React.useEffect(() => {
+        // forcing resize event to make Div100vh re-render when height_offset has changed:
+        window.dispatchEvent(new Event('resize'));
+    }, [height_offset]);
+
     if (is_bypassed) return children as JSX.Element;
     return (
         <Div100vh id={id} className={className} style={is_disabled ? {} : height_style} data-testid='dt_div_100_vh'>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -95,7 +95,7 @@
         "@deriv/cfd": "^1.0.0",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.11",
-        "@deriv/deriv-charts": "1.1.6",
+        "@deriv/deriv-charts": "1.1.7",
         "@deriv/hooks": "^1.0.0",
         "@deriv/p2p": "^0.7.3",
         "@deriv/reports": "^1.0.0",

--- a/packages/shared/src/utils/contract/contract.ts
+++ b/packages/shared/src/utils/contract/contract.ts
@@ -157,4 +157,4 @@ export const shouldShowExpiration = (symbol: string) => /^cry/.test(symbol);
 
 export const shouldShowCancellation = (symbol: string) => !/^(cry|CRASH|BOOM|stpRNG|WLD|JD)/.test(symbol);
 
-export const getTurbosSubtype = (type: string) => type.slice(6)[0] + type.toLowerCase().slice(7);
+export const getTurbosSubtype = (type: string) => type[6] + type.toLowerCase().slice(7);

--- a/packages/shared/src/utils/contract/contract.ts
+++ b/packages/shared/src/utils/contract/contract.ts
@@ -157,8 +157,4 @@ export const shouldShowExpiration = (symbol: string) => /^cry/.test(symbol);
 
 export const shouldShowCancellation = (symbol: string) => !/^(cry|CRASH|BOOM|stpRNG|WLD|JD)/.test(symbol);
 
-export const getSubType = (type: string) => {
-    const subtype: string[] = type.toLowerCase().replace('turbos', '').split('');
-    subtype[0] = subtype[0].toUpperCase();
-    return `${subtype.join('')}`;
-};
+export const getTurbosSubtype = (type: string) => type.slice(6)[0] + type.toLowerCase().slice(7);

--- a/packages/trader/package.json
+++ b/packages/trader/package.json
@@ -86,7 +86,7 @@
         "@deriv/api-types": "^1.0.11",
         "@deriv/components": "^1.0.0",
         "@deriv/deriv-api": "^1.0.11",
-        "@deriv/deriv-charts": "1.1.6",
+        "@deriv/deriv-charts": "1.1.7",
         "@deriv/reports": "^1.0.0",
         "@deriv/shared": "^1.0.0",
         "@deriv/stores": "^1.0.0",

--- a/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.jsx
+++ b/packages/trader/src/App/Components/Elements/TogglePositions/toggle-positions-mobile.jsx
@@ -43,7 +43,10 @@ const TogglePositionsMobile = ({
         p =>
             p.contract_info &&
             symbol === p.contract_info.underlying &&
-            filterByContractType(p.contract_info, trade_contract_type)
+            (trade_contract_type.includes('turbos')
+                ? filterByContractType(p.contract_info, 'turbosshort') ||
+                  filterByContractType(p.contract_info, 'turboslong')
+                : filterByContractType(p.contract_info, trade_contract_type))
     );
 
     // Show only 5 most recent open contracts

--- a/packages/trader/src/Modules/Trading/Components/Elements/Turbos/payout-per-point.tsx
+++ b/packages/trader/src/Modules/Trading/Components/Elements/Turbos/payout-per-point.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import { Money, Text, Popover } from '@deriv/components';
-import { localize } from '@deriv/translations';
+import { Localize, localize } from '@deriv/translations';
 import Fieldset from 'App/Components/Form/fieldset.jsx';
 import { observer, useStore } from '@deriv/stores';
 
@@ -13,8 +13,18 @@ const PayoutPerPoint = observer(() => {
     const label = localize('Payout per point');
     const contract_key = contract_type?.toUpperCase();
     const stake = proposal_info?.[contract_key]?.number_of_contracts || 0;
-    const message = proposal_info?.[contract_key]?.message || ' ';
 
+    const message = proposal_info?.[contract_key]?.message;
+    const payout_per_point_text = (
+        <Localize
+            i18n_default_text='<0>For {{title}}: </0>{{message}}'
+            components={[<Text key={0} weight='bold' size='xxs' />]}
+            values={{
+                title: contract_type === 'turboslong' ? localize('Long') : localize('Short'),
+                message,
+            }}
+        />
+    );
     return (
         <Fieldset className={classNames('payout-per-point')}>
             <div className='payout-per-point__text-popover'>
@@ -27,7 +37,7 @@ const PayoutPerPoint = observer(() => {
                     is_bubble_hover_enabled
                     margin={0}
                     zIndex='9999'
-                    message={message}
+                    message={message ? payout_per_point_text : ''}
                 />
             </div>
             <Text size='xs' weight='bold' className='payout-per-point__currency'>

--- a/packages/trader/src/Modules/Trading/Components/Elements/purchase-fieldset.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Elements/purchase-fieldset.jsx
@@ -69,6 +69,7 @@ const PurchaseFieldset = ({
         <Fieldset
             className={classNames('trade-container__fieldset', 'purchase-container__option', {
                 'purchase-container__option--has-cancellation': has_cancellation,
+                'purchase-container__option--vanilla': is_vanilla,
             })}
         >
             <DesktopWrapper>

--- a/packages/trader/src/Modules/Trading/Components/Form/Purchase/contract-info.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/Purchase/contract-info.jsx
@@ -89,6 +89,18 @@ const ContractInfo = ({
                 />
             );
         }
+        if (['TURBOSLONG', 'TURBOSSHORT'].includes(type)) {
+            return (
+                <Localize
+                    i18n_default_text='<0>For {{title}}:</0> {{message}}'
+                    components={[<Text key={0} weight='bold' size='xxs' />]}
+                    values={{
+                        title: type === 'TURBOSLONG' ? localize('Long') : localize('Short'),
+                        message,
+                    }}
+                />
+            );
+        }
         return message;
     };
 

--- a/packages/trader/src/Modules/Trading/Components/Form/Purchase/contract-info.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/Purchase/contract-info.jsx
@@ -7,7 +7,7 @@ import { getCurrencyDisplayCode, getLocalizedBasis, isMobile } from '@deriv/shar
 import CancelDealInfo from './cancel-deal-info.jsx';
 
 const ValueMovement = ({ has_error_or_not_loaded, proposal_info, currency, has_increased, is_turbos, is_vanilla }) => (
-    <div className={is_vanilla ? 'strike--value-container' : ''}>
+    <div className='strike--value-container'>
         <div className={classNames('trade-container__price-info-value', { 'strike--info': is_vanilla })}>
             {!has_error_or_not_loaded && (
                 <Money

--- a/packages/trader/src/Modules/Trading/Components/Form/screen-small.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/screen-small.jsx
@@ -86,11 +86,7 @@ const CollapsibleTradeParams = ({
                     <RiskManagementInfo />
                 </div>
             )}
-            {is_turbos && (
-                <div collapsible='true'>
-                    <PayoutPerPoint />
-                </div>
-            )}
+            {is_turbos && <PayoutPerPoint />}
             {is_vanilla ? (
                 <Purchase />
             ) : (

--- a/packages/trader/src/Modules/Trading/Components/Form/screen-small.jsx
+++ b/packages/trader/src/Modules/Trading/Components/Form/screen-small.jsx
@@ -69,7 +69,11 @@ const CollapsibleTradeParams = ({
                     <BarrierMobile />
                 </div>
             )}
-            {isVisible('barrier_selector') && <BarrierSelector />}
+            {isVisible('barrier_selector') && (
+                <div collapsible='true'>
+                    <BarrierSelector />
+                </div>
+            )}
             {isVisible('strike') && (
                 <div collapsible='true'>
                     <Strike />
@@ -82,7 +86,11 @@ const CollapsibleTradeParams = ({
                     <RiskManagementInfo />
                 </div>
             )}
-            {is_turbos && <PayoutPerPoint />}
+            {is_turbos && (
+                <div collapsible='true'>
+                    <PayoutPerPoint />
+                </div>
+            )}
             {is_vanilla ? (
                 <Purchase />
             ) : (

--- a/packages/trader/src/Modules/Trading/Containers/trade.jsx
+++ b/packages/trader/src/Modules/Trading/Containers/trade.jsx
@@ -54,6 +54,7 @@ const Trade = ({
     is_synthetics_available,
     is_synthetics_trading_market_available,
     is_vanilla,
+    is_turbos,
 }) => {
     const [digits, setDigits] = React.useState([]);
     const [tick, setTick] = React.useState({});
@@ -146,7 +147,12 @@ const Trade = ({
     const form_wrapper_class = isMobile() ? 'mobile-wrapper' : 'sidebar__container desktop-only';
 
     return (
-        <div id='trade_container' className='trade-container'>
+        <div
+            id='trade_container'
+            className={classNames('trade-container', {
+                'trade-container--turbos': is_turbos,
+            })}
+        >
             <DesktopWrapper>
                 <PositionsDrawer />
             </DesktopWrapper>
@@ -157,7 +163,7 @@ const Trade = ({
                 id='chart_container'
                 className='chart-container'
                 is_disabled={isDesktop()}
-                height_offset='259px'
+                height_offset={is_turbos ? '300px' : '259px'}
             >
                 <NotificationMessages />
                 <React.Suspense
@@ -248,6 +254,7 @@ export default connect(({ client, common, modules, ui }) => ({
     onChange: modules.trade.onChange,
     setContractTypes: modules.trade.setContractTypes,
     is_vanilla: modules.trade.is_vanilla,
+    is_turbos: modules.trade.is_turbos,
 }))(Trade);
 
 // CHART (ChartTrade)--------------------------------------------------------

--- a/packages/trader/src/sass/app/_common/layout/trader-layouts.scss
+++ b/packages/trader/src/sass/app/_common/layout/trader-layouts.scss
@@ -78,6 +78,9 @@ $FLOATING_HEADER_HEIGHT: 41px;
     min-height: calc(100vh - 84px);
     overflow: hidden;
 
+    &--turbos {
+        justify-content: space-between;
+    }
     &__replay {
         width: 100%;
         display: flex;

--- a/packages/trader/src/sass/app/modules/trading.scss
+++ b/packages/trader/src/sass/app/modules/trading.scss
@@ -763,8 +763,10 @@
     position: relative;
 
     &__option {
-        padding: 1.6rem 0.8rem;
-
+        padding: 0.8rem;
+        &--vanilla {
+            padding: 1.6rem 0.8rem;
+        }
         &:not(:only-child) {
             &:nth-last-child(2) {
                 border-bottom-width: 0;

--- a/packages/trader/src/sass/app/modules/trading.scss
+++ b/packages/trader/src/sass/app/modules/trading.scss
@@ -599,8 +599,6 @@
         }
     }
     &__trade {
-        position: relative;
-        top: 0.2rem;
         &-type-tabs {
             border-radius: $BORDER_RADIUS;
             padding: 0.8rem;


### PR DESCRIPTION
## Changes:

- `BarrierSelector` is now collapsible in responsive.
- Rename and refactor `getTurbosSubtype` function.
- Add cards filtration for responsive (based on hat we have for desktop).
- Lift up the mobile chart as it was covered by trade parameters.
- Add more details to tooltip text.
- Update version of `@deriv/deriv-charts` to 1.1.7.

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
