### PR TITLE
Kate/91602/To display Long and Short open contracts in DTrader chart simultaneously

### DIFF
--- a/packages/reports/src/Containers/open-positions.jsx
+++ b/packages/reports/src/Containers/open-positions.jsx
@@ -20,11 +20,14 @@ import {
     isMobile,
     isMultiplierContract,
     isVanillaContract,
+    isTurbosContract,
     getTimePercentage,
     website_name,
     getTotalProfit,
     getContractPath,
     getCurrentTick,
+    getDurationTurbosText,
+    getDurationPeriod,
 } from '@deriv/shared';
 import { localize, Localize } from '@deriv/translations';
 import { ReportsTableRowLoader } from '../Components/Elements/ContentLoader';
@@ -94,7 +97,8 @@ const MobileRowRenderer = ({
     const { contract_info, contract_update, type, is_sell_requested } = row;
     const { currency, status, date_expiry, date_start, tick_count, purchase_time } = contract_info;
     const current_tick = tick_count ? getCurrentTick(contract_info) : null;
-    const duration_type = getContractDurationType(contract_info.longcode);
+    const turbos_duration_unit = tick_count ? 'ticks' : getDurationTurbosText(getDurationPeriod(contract_info));
+    const duration_type = getContractDurationType(isTurbosContract ? turbos_duration_unit : contract_info.longcode);
     const progress_value = getTimePercentage(server_time, date_start, date_expiry) / 100;
 
     if (isMultiplierContract(type)) {

--- a/packages/shared/src/utils/helpers/details.ts
+++ b/packages/shared/src/utils/helpers/details.ts
@@ -69,6 +69,25 @@ export const getDurationUnitText = (obj_duration: moment.Duration) => {
     }
     return unit_map.s.name;
 };
+export const getDurationTurbosText = (obj_duration: moment.Duration) => {
+    const unit_map = getUnitMap();
+    const duration_ms = obj_duration.asMilliseconds() / 1000;
+    // return empty suffix string if duration is End Time set except for days and seconds, refer to L18 and L19
+
+    if (duration_ms) {
+        if (duration_ms >= 86400000) {
+            const days_value = duration_ms / 86400000;
+            return days_value <= 2 ? unit_map.d.name_singular : unit_map.d.name_plural;
+        } else if (duration_ms >= 3600000 && duration_ms < 86400000) {
+            return duration_ms === 3600000 ? unit_map.h.name_singular : unit_map.h.name_plural;
+        } else if (duration_ms >= 60000 && duration_ms < 3600000) {
+            return duration_ms === 60000 ? unit_map.m.name_singular : unit_map.m.name_plural;
+        } else if (duration_ms >= 1000 && duration_ms < 60000) {
+            return unit_map.s.name;
+        }
+    }
+    return unit_map.s.name;
+};
 
 export const getDurationPeriod = (contract_info: TGetDurationPeriod) =>
     getDiffDuration(

--- a/packages/trader/src/Assets/Trading/Categories/turbos-trade-description.tsx
+++ b/packages/trader/src/Assets/Trading/Categories/turbos-trade-description.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { localize } from '@deriv/translations';
+import { Text } from '@deriv/components';
 
 export const TurbosTradeDescription = () => {
     const content = [
@@ -51,11 +52,13 @@ export const TurbosTradeDescription = () => {
                 /* We're using the array’s indexes as keys in this “static” list, which is never re-ordered, for better performance. https://www.developerway.com/posts/react-key-attribute
             We're not using text itself as keys here because text will update each time platform language is changed. */
                 type === 'heading' ? (
-                    <h2 key={index}>
-                        <strong>{text}</strong>
-                    </h2>
+                    <Text as='h2' key={index} weight='bold'>
+                        {text}
+                    </Text>
                 ) : (
-                    <p key={index}>{text}</p>
+                    <Text as='p' key={index}>
+                        {text}
+                    </Text>
                 )
             )}
         </React.Fragment>


### PR DESCRIPTION
## Changes:

- Add `getDurationTurbosText` function in order to get contract duration for Turbos.
- Add `Text` component into turbos-trade-description.tsx file.

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
