### PR TITLE
Kate/91602/Display Long and Short open contracts in DTrader chart simultaneously

### DIFF
--- a/packages/core/src/Stores/contract-trade-store.js
+++ b/packages/core/src/Stores/contract-trade-store.js
@@ -73,12 +73,12 @@ export default class ContractTradeStore extends BaseStore {
 
     applicable_contracts = () => {
         const { symbol: underlying, contract_type: trade_type } = JSON.parse(localStorage.getItem('trade_store')) || {};
+
         if (!trade_type || !underlying) {
             return [];
         }
         let { trade_types } = getContractTypesConfig()[trade_type];
         const is_call_put = isCallPut(trade_type);
-
         if (is_call_put) {
             // treat CALLE/PUTE and CALL/PUT the same
             trade_types = ['CALLE', 'PUTE', 'CALL', 'PUT'];
@@ -87,6 +87,7 @@ export default class ContractTradeStore extends BaseStore {
             //to show both Long and Short recent contracts on DTrader chart
             trade_types = ['TURBOSLONG', 'TURBOSSHORT'];
         }
+
         return this.contracts
             .filter(c => c.contract_info.underlying === underlying)
             .filter(c => {

--- a/packages/core/src/Stores/contract-trade-store.js
+++ b/packages/core/src/Stores/contract-trade-store.js
@@ -6,6 +6,7 @@ import {
     LocalStore,
     switch_to_tick_chart,
     isCallPut,
+    isTurbosContract,
     getContractTypesConfig,
 } from '@deriv/shared';
 import ContractStore from './contract-store';
@@ -72,15 +73,19 @@ export default class ContractTradeStore extends BaseStore {
 
     applicable_contracts = () => {
         const { symbol: underlying, contract_type: trade_type } = JSON.parse(localStorage.getItem('trade_store')) || {};
-
         if (!trade_type || !underlying) {
             return [];
         }
         let { trade_types } = getContractTypesConfig()[trade_type];
         const is_call_put = isCallPut(trade_type);
+
         if (is_call_put) {
             // treat CALLE/PUTE and CALL/PUT the same
             trade_types = ['CALLE', 'PUTE', 'CALL', 'PUT'];
+        }
+        if (isTurbosContract(trade_type)) {
+            //to show both Long and Short recent contracts on DTrader chart
+            trade_types = ['TURBOSLONG', 'TURBOSSHORT'];
         }
         return this.contracts
             .filter(c => c.contract_info.underlying === underlying)

--- a/packages/shared/src/utils/contract/contract.ts
+++ b/packages/shared/src/utils/contract/contract.ts
@@ -162,10 +162,10 @@ export const getContractSubtype = (type: string) => {
     switch (contract_type) {
         case 'VANILLALONGCALL':
         case 'VANILLALONGPUT':
-            return contract_type[11] + contract_type.toLowerCase().slice(12);
+            return contract_type[11] + type.toLowerCase().slice(12);
         case 'TURBOSLONG':
         case 'TURBOSSHORT':
-            return contract_type[6] + contract_type.toLowerCase().slice(7);
+            return contract_type[6] + type.toLowerCase().slice(7);
         default:
             return '';
     }

--- a/packages/shared/src/utils/contract/contract.ts
+++ b/packages/shared/src/utils/contract/contract.ts
@@ -158,13 +158,14 @@ export const shouldShowExpiration = (symbol: string) => /^cry/.test(symbol);
 export const shouldShowCancellation = (symbol: string) => !/^(cry|CRASH|BOOM|stpRNG|WLD|JD)/.test(symbol);
 
 export const getContractSubtype = (type: string) => {
-    switch (type) {
+    const contract_type = type.toUpperCase();
+    switch (contract_type) {
         case 'VANILLALONGCALL':
         case 'VANILLALONGPUT':
-            return type[11] + type.toLowerCase().slice(12);
+            return contract_type[11] + contract_type.toLowerCase().slice(12);
         case 'TURBOSLONG':
         case 'TURBOSSHORT':
-            return type[6] + type.toLowerCase().slice(7);
+            return contract_type[6] + contract_type.toLowerCase().slice(7);
         default:
             return '';
     }

--- a/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.js
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.js
@@ -14,6 +14,7 @@ import {
     unsupported_contract_types_list,
     getContractCategoriesConfig,
     getContractTypesConfig,
+    getContractSubtype,
     getLocalizedBasis,
 } from '@deriv/shared';
 import ServerTime from '_common/base/server_time';
@@ -109,21 +110,30 @@ export const ContractType = (() => {
             start_date,
             cancellation_duration,
             symbol,
+            short_barriers,
+            long_barriers,
         } = store;
 
         if (!contract_type) return {};
+
+        let barriers_options;
+        if (getContractSubtype(contract_type) === 'Short') {
+            barriers_options = short_barriers;
+        } else if (getContractSubtype(contract_type) === 'Long') {
+            barriers_options = long_barriers;
+        }
 
         const form_components = getComponents(contract_type);
         const obj_basis = getBasis(contract_type, basis);
         const obj_trade_types = getTradeTypes(contract_type);
         const obj_start_dates = getStartDates(contract_type, start_date);
         const obj_start_type = getStartType(obj_start_dates.start_date);
-        const obj_barrier = getBarriers(contract_type, contract_expiry_type);
+        const obj_barrier = getBarriers(contract_type, contract_expiry_type, barriers_options?.[0]);
         const obj_duration_unit = getDurationUnit(duration_unit, contract_type, obj_start_type.contract_start_type);
 
         const obj_duration_units_list = getDurationUnitsList(contract_type, obj_start_type.contract_start_type);
         const obj_duration_units_min_max = getDurationMinMax(contract_type, obj_start_type.contract_start_type);
-        const obj_turbos_barrier_choices = getTurbosBarrierChoices(contract_type);
+        const obj_turbos_barrier_choices = getTurbosBarrierChoices(contract_type, barriers_options);
         const obj_multiplier_range_list = getMultiplierRange(contract_type, multiplier);
         const obj_cancellation = getCancellation(contract_type, cancellation_duration, symbol);
         const obj_expiry_type = getExpiryType(obj_duration_units_list, expiry_type);
@@ -473,14 +483,15 @@ export const ContractType = (() => {
         trade_types: getPropertyValue(available_contract_types, [contract_type, 'config', 'trade_types']),
     });
 
-    const getBarriers = (contract_type, expiry_type) => {
+    const getBarriers = (contract_type, expiry_type, default_barrier_value) => {
         const barriers = getPropertyValue(available_contract_types, [contract_type, 'config', 'barriers']) || {};
         const barrier_values = barriers[expiry_type] || {};
         const barrier_1 = barrier_values.barrier || barrier_values.high_barrier || '';
         const barrier_2 = barrier_values.low_barrier || '';
+
         return {
             barrier_count: barriers.count || 0,
-            barrier_1: barrier_1.toString(),
+            barrier_1: default_barrier_value || barrier_1.toString(),
             barrier_2: barrier_2.toString(),
         };
     };
@@ -496,9 +507,10 @@ export const ContractType = (() => {
         };
     };
 
-    const getTurbosBarrierChoices = contract_type => ({
-        turbos_barrier_choices:
-            getPropertyValue(available_contract_types, [contract_type, 'config', 'barrier_choices']) || [],
+    const getTurbosBarrierChoices = (contract_type, turbos_barriers) => ({
+        turbos_barrier_choices: turbos_barriers?.length
+            ? turbos_barriers
+            : getPropertyValue(available_contract_types, [contract_type, 'config', 'barrier_choices']) || [],
     });
 
     const getMultiplierRange = (contract_type, multiplier) => {

--- a/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.js
+++ b/packages/trader/src/Stores/Modules/Trading/Helpers/contract-type.js
@@ -116,7 +116,7 @@ export const ContractType = (() => {
 
         if (!contract_type) return {};
 
-        let barriers_options;
+        let barriers_options = [];
         if (getContractSubtype(contract_type) === 'Short') {
             barriers_options = short_barriers;
         } else if (getContractSubtype(contract_type) === 'Long') {
@@ -128,7 +128,7 @@ export const ContractType = (() => {
         const obj_trade_types = getTradeTypes(contract_type);
         const obj_start_dates = getStartDates(contract_type, start_date);
         const obj_start_type = getStartType(obj_start_dates.start_date);
-        const obj_barrier = getBarriers(contract_type, contract_expiry_type, barriers_options?.[0]);
+        const obj_barrier = getBarriers(contract_type, contract_expiry_type, barriers_options[0]);
         const obj_duration_unit = getDurationUnit(duration_unit, contract_type, obj_start_type.contract_start_type);
 
         const obj_duration_units_list = getDurationUnitsList(contract_type, obj_start_type.contract_start_type);
@@ -483,15 +483,14 @@ export const ContractType = (() => {
         trade_types: getPropertyValue(available_contract_types, [contract_type, 'config', 'trade_types']),
     });
 
-    const getBarriers = (contract_type, expiry_type, default_barrier_value) => {
+    const getBarriers = (contract_type, expiry_type, stored_barrier_value) => {
         const barriers = getPropertyValue(available_contract_types, [contract_type, 'config', 'barriers']) || {};
         const barrier_values = barriers[expiry_type] || {};
         const barrier_1 = barrier_values.barrier || barrier_values.high_barrier || '';
         const barrier_2 = barrier_values.low_barrier || '';
-
         return {
             barrier_count: barriers.count || 0,
-            barrier_1: default_barrier_value || barrier_1.toString(),
+            barrier_1: stored_barrier_value || barrier_1.toString(),
             barrier_2: barrier_2.toString(),
         };
     };
@@ -507,9 +506,9 @@ export const ContractType = (() => {
         };
     };
 
-    const getTurbosBarrierChoices = (contract_type, turbos_barriers) => ({
-        turbos_barrier_choices: turbos_barriers?.length
-            ? turbos_barriers
+    const getTurbosBarrierChoices = (contract_type, stored_turbos_barriers) => ({
+        turbos_barrier_choices: stored_turbos_barriers.length
+            ? stored_turbos_barriers
             : getPropertyValue(available_contract_types, [contract_type, 'config', 'barrier_choices']) || [],
     });
 

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.js
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.js
@@ -10,6 +10,7 @@ import {
     getMinPayout,
     getPlatformSettings,
     getPropertyValue,
+    getContractSubtype,
     isBarrierSupported,
     isCryptocurrency,
     isDesktop,
@@ -139,6 +140,8 @@ export default class TradeStore extends BaseStore {
     // Turbos trade params
     number_of_contracts = 0;
     turbos_barrier_choices = [];
+    short_barriers = [];
+    long_barriers = [];
     min_stake = 0;
     max_stake = 0;
 
@@ -175,6 +178,8 @@ export default class TradeStore extends BaseStore {
             'has_stop_loss',
             'has_cancellation',
             'hovered_barrier',
+            'short_barriers',
+            'long_barriers',
             'is_equal',
             'last_digit',
             'multiplier',
@@ -224,6 +229,8 @@ export default class TradeStore extends BaseStore {
             has_stop_loss: observable,
             has_take_profit: observable,
             hovered_barrier: observable,
+            short_barriers: observable,
+            long_barriers: observable,
             hovered_contract_type: observable,
             is_chart_loading: observable,
             is_equal: observable,
@@ -1075,7 +1082,11 @@ export default class TradeStore extends BaseStore {
             const contract_key = this.contract_type.toUpperCase();
             if (this.proposal_info[contract_key]) {
                 const { barrier_choices, number_of_contracts, max_stake, min_stake } = this.proposal_info[contract_key];
-
+                if (getContractSubtype(contract_key) === 'Short') {
+                    this.short_barriers = barrier_choices;
+                } else {
+                    this.long_barriers = barrier_choices;
+                }
                 this.turbos_barrier_choices = barrier_choices || [];
                 this.number_of_contracts = number_of_contracts ?? 0;
                 this.max_stake = max_stake ?? 0;


### PR DESCRIPTION
## Changes:

- Change `contract-trade-store.js` in order to show both `Long` and `Short` recent contracts on DTrader chart.
- Add `short_barriers` and `long_barriers` into the store in order to display correct barrier value after switching between different contract type and 1-st page loading.

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [ ] Bug fix
-   [ ] New feature
-   [x] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
