### PR TITLE
Kate/93137/Profit value is not displayed right in the contract details page

### DIFF
--- a/packages/components/src/components/contract-card/contract-card-items/__tests__/turbos-card-body.spec.tsx
+++ b/packages/components/src/components/contract-card/contract-card-items/__tests__/turbos-card-body.spec.tsx
@@ -93,7 +93,7 @@ describe('TurbosCardBody', () => {
 
         const profit_loss_header = screen.getByText(mockCardLabels().PROFIT_LOSS);
         expect(profit_loss_header).toBeInTheDocument();
-        const profit_loss_amount = screen.getByText('1,044.00');
+        const profit_loss_amount = screen.getByText('50.00');
         expect(profit_loss_amount).toBeInTheDocument();
 
         const payout_header = screen.getByText(mockCardLabels().PAYOUT);

--- a/packages/components/src/components/contract-card/contract-card-items/__tests__/turbos-card-body.spec.tsx
+++ b/packages/components/src/components/contract-card/contract-card-items/__tests__/turbos-card-body.spec.tsx
@@ -103,7 +103,7 @@ describe('TurbosCardBody', () => {
 
         const buy_price_header = screen.getByText(mockCardLabels().BUY_PRICE);
         expect(buy_price_header).toBeInTheDocument();
-        const buy_price_amount = screen.getByText('1,054.00');
+        const buy_price_amount = screen.getByText('10,904.80');
         expect(buy_price_amount).toBeInTheDocument();
 
         const take_profit_header = screen.queryByText(mockCardLabels().TAKE_PROFIT);

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.tsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.tsx
@@ -87,11 +87,15 @@ const TurbosCardBody = ({
                     is_crypto={isCryptocurrency(currency)}
                     className='dc-contract-card__buy-price'
                 >
-                    <Money amount={is_sold ? entry_spot : barrier} currency={currency} />
+                    <Money
+                        amount={is_sold ? entry_spot : barrier}
+                        currency={currency}
+                        should_format={is_sold && false}
+                    />
                 </ContractCardItem>
                 {is_sold ? (
                     <ContractCardItem header={BARRIER_LEVEL} className='dc-contract-card__barrier-level'>
-                        <Money amount={barrier} currency={currency} />
+                        <Money amount={barrier} currency={currency} should_format={false} />
                     </ContractCardItem>
                 ) : (
                     <div className='dc-contract-card__limit-order-info'>

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.tsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.tsx
@@ -90,7 +90,7 @@ const TurbosCardBody = ({
                     <Money
                         amount={is_sold ? entry_spot : addComma(barrier)}
                         currency={currency}
-                        should_format={!!is_sold}
+                        should_format={is_sold}
                     />
                 </ContractCardItem>
                 {is_sold ? (

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.tsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.tsx
@@ -77,7 +77,7 @@ const TurbosCardBody = ({
                     is_loss={is_sold && profit ? profit < 0 : false}
                     is_won={is_sold && profit ? profit > 0 : false}
                 >
-                    <Money amount={buy_price} currency={currency} />
+                    <Money amount={is_sold ? profit : buy_price} currency={currency} />
                 </ContractCardItem>
                 <ContractCardItem header={is_sold ? PAYOUT : CURRENT_PRICE} className='dc-contract-card__current-price'>
                     <Money currency={currency} amount={sell_spot || current_spot_display_value} />

--- a/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.tsx
+++ b/packages/components/src/components/contract-card/contract-card-items/turbos-card-body.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
-import { isCryptocurrency, getLimitOrderAmount, isValidToSell } from '@deriv/shared';
+import { isCryptocurrency, getLimitOrderAmount, isValidToSell, addComma } from '@deriv/shared';
 import ContractCardItem from './contract-card-item.jsx';
 import ToggleCardDialog from './toggle-card-dialog.jsx';
 import Icon from '../../icon';
@@ -88,14 +88,14 @@ const TurbosCardBody = ({
                     className='dc-contract-card__buy-price'
                 >
                     <Money
-                        amount={is_sold ? entry_spot : barrier}
+                        amount={is_sold ? entry_spot : addComma(barrier)}
                         currency={currency}
-                        should_format={is_sold && false}
+                        should_format={!!is_sold}
                     />
                 </ContractCardItem>
                 {is_sold ? (
                     <ContractCardItem header={BARRIER_LEVEL} className='dc-contract-card__barrier-level'>
-                        <Money amount={barrier} currency={currency} should_format={false} />
+                        <Money amount={addComma(barrier)} currency={currency} should_format={false} />
                     </ContractCardItem>
                 ) : (
                     <div className='dc-contract-card__limit-order-info'>

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.js
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.js
@@ -1245,7 +1245,7 @@ export default class TradeStore extends BaseStore {
 
             // Sometimes the initial barrier doesn't match with current barrier choices received from API.
             // When this happens we want to populate the list of barrier choices to choose from since the value cannot be specified manually
-            if ((this.is_turbos || this.is_vanilla) && response?.error?.details?.barrier_choices) {
+            if ((this.is_turbos || this.is_vanilla) && response.error.details?.barrier_choices) {
                 const { barrier_choices, max_stake, min_stake } = response.error.details;
                 this.setStakeBoundary(contract_type, min_stake, max_stake);
                 this.setBarrierChoices(barrier_choices);

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.js
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.js
@@ -1253,7 +1253,7 @@ export default class TradeStore extends BaseStore {
                     // Since on change of duration `proposal` API call is made which returns a new set of barrier values.
                     // The new list is set and the mid value is assigned
                     const index = Math.floor(this.barrier_choices.length / 2);
-                    this.barrier_1 = this.barrier_choices[index];
+                    this.barrier_1 = this.is_vanilla ? this.barrier_choices[index] : this.barrier_choices[0];
                     this.onChange({
                         target: {
                             name: 'barrier_1',

--- a/packages/trader/src/Stores/Modules/Trading/trade-store.js
+++ b/packages/trader/src/Stores/Modules/Trading/trade-store.js
@@ -1245,7 +1245,7 @@ export default class TradeStore extends BaseStore {
 
             // Sometimes the initial barrier doesn't match with current barrier choices received from API.
             // When this happens we want to populate the list of barrier choices to choose from since the value cannot be specified manually
-            if ((this.is_turbos || this.is_vanilla) && response.error.details.barrier_choices) {
+            if ((this.is_turbos || this.is_vanilla) && response?.error?.details?.barrier_choices) {
                 const { barrier_choices, max_stake, min_stake } = response.error.details;
                 this.setStakeBoundary(contract_type, min_stake, max_stake);
                 this.setBarrierChoices(barrier_choices);


### PR DESCRIPTION
## Changes:

- Add profit value into turbos-card-body (after contract is sold)
- Remove default barrier formatting, but add comma

## When you need to add unit test

-   [ ] If this change disrupt current flow
-   [ ] If this change is adding new flow

## When you need to add integration test

-   [ ] If components from external libraries are being used to define the flow, e.g. @deriv/components
-   [ ] If it relies on a very specific set of props with no default behavior for the current component.

## Test coverage checklist (for reviewer)

-   [ ] Ensure utility / function has a test case 
-   [ ] Ensure all the tests are passing

## Type of change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Update feature
-   [x] Refactor code
-   [ ] Translation to code
-   [ ] Translation to crowdin
-   [ ] Script configuration
-   [ ] Improve performance
-   [ ] Style only
-   [ ] Dependency update
-   [ ] Documentation update
-   [ ] Release
