### PR TITLE
DTRA-1469 / Kate / Implement Allow equals trade param and Carousel functionality

### DIFF
--- a/packages/trader/src/AppV2/Components/Carousel/__tests__/carousel.spec.tsx
+++ b/packages/trader/src/AppV2/Components/Carousel/__tests__/carousel.spec.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Carousel from '../carousel';
+
+const PAGES = {
+    FIRST: 'first page',
+    SECOND: 'second page',
+};
+const data_test_id = 'dt_page';
+const mock_pages = [
+    {
+        id: PAGES.FIRST,
+        component: (onNextClick: () => void) => (
+            <button onClick={onNextClick} data-testid={data_test_id}>
+                <span>{PAGES.FIRST}</span>
+                <span>Next</span>
+            </button>
+        ),
+    },
+    {
+        id: PAGES.SECOND,
+        component: (onPrevClick: () => void) => (
+            <button onClick={onPrevClick} data-testid={data_test_id}>
+                <span>{PAGES.SECOND}</span>
+                <span>Previous</span>
+            </button>
+        ),
+    },
+];
+
+describe('Carousel', () => {
+    it('should render all passed pages', () => {
+        render(<Carousel pages={mock_pages} />);
+
+        expect(screen.getByText(PAGES.FIRST)).toBeInTheDocument();
+        expect(screen.getByText(PAGES.SECOND)).toBeInTheDocument();
+        expect(screen.getAllByTestId(data_test_id)).toHaveLength(mock_pages.length);
+    });
+
+    it('should set index to 1 if user clicks on "Next"', () => {
+        const mockSetCurrentIndex = jest.fn();
+        jest.spyOn(React, 'useState').mockImplementationOnce(() => [0, mockSetCurrentIndex]);
+        render(<Carousel pages={mock_pages} />);
+
+        userEvent.click(screen.getByText('Next'));
+        expect(mockSetCurrentIndex).toBeCalledWith(1);
+    });
+
+    it('should set index to 0 if user clicks on "Previous"', () => {
+        const mockSetCurrentIndex = jest.fn();
+        jest.spyOn(React, 'useState').mockImplementationOnce(() => [1, mockSetCurrentIndex]);
+        render(<Carousel pages={mock_pages} />);
+
+        userEvent.click(screen.getByText('Previous'));
+
+        expect(mockSetCurrentIndex).toBeCalledWith(0);
+    });
+
+    it('should set index to 0 if should_reset_carousel is true', () => {
+        const mockSetCurrentIndex = jest.fn();
+        jest.spyOn(React, 'useState').mockImplementationOnce(() => [1, mockSetCurrentIndex]);
+        render(<Carousel pages={mock_pages} should_reset_carousel />);
+
+        expect(mockSetCurrentIndex).toBeCalledWith(0);
+    });
+});

--- a/packages/trader/src/AppV2/Components/Carousel/__tests__/carousel.spec.tsx
+++ b/packages/trader/src/AppV2/Components/Carousel/__tests__/carousel.spec.tsx
@@ -3,27 +3,21 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Carousel from '../carousel';
 
-const PAGES = {
-    FIRST: 'first page',
-    SECOND: 'second page',
-};
 const data_test_id = 'dt_page';
 const mock_pages = [
     {
-        id: PAGES.FIRST,
+        id: 1,
         component: (onNextClick: () => void) => (
             <button onClick={onNextClick} data-testid={data_test_id}>
-                <span>{PAGES.FIRST}</span>
-                <span>Next</span>
+                Next
             </button>
         ),
     },
     {
-        id: PAGES.SECOND,
+        id: 2,
         component: (onPrevClick: () => void) => (
             <button onClick={onPrevClick} data-testid={data_test_id}>
-                <span>{PAGES.SECOND}</span>
-                <span>Previous</span>
+                Previous
             </button>
         ),
     },
@@ -33,8 +27,6 @@ describe('Carousel', () => {
     it('should render all passed pages', () => {
         render(<Carousel pages={mock_pages} />);
 
-        expect(screen.getByText(PAGES.FIRST)).toBeInTheDocument();
-        expect(screen.getByText(PAGES.SECOND)).toBeInTheDocument();
         expect(screen.getAllByTestId(data_test_id)).toHaveLength(mock_pages.length);
     });
 

--- a/packages/trader/src/AppV2/Components/Carousel/carousel.scss
+++ b/packages/trader/src/AppV2/Components/Carousel/carousel.scss
@@ -6,7 +6,7 @@
     &__item {
         width: 100vw;
         min-width: 100vw;
-        transition: transform 0.5s ease-in-out;
+        transition: transform 0.24s ease-in-out;
     }
 
     //TODO: temporary, because quill doesn't support positioning of icon in header

--- a/packages/trader/src/AppV2/Components/Carousel/carousel.scss
+++ b/packages/trader/src/AppV2/Components/Carousel/carousel.scss
@@ -1,0 +1,19 @@
+.carousel {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: hidden;
+
+    &__item {
+        width: 100vw;
+        min-width: 100vw;
+        transition: transform 0.5s ease-in-out;
+    }
+
+    //TODO: temporary, because quill doesn't support positioning of icon in header
+    .icon--left {
+        .quill-action-sheet--title--icon {
+            right: unset;
+            left: 0;
+        }
+    }
+}

--- a/packages/trader/src/AppV2/Components/Carousel/carousel.tsx
+++ b/packages/trader/src/AppV2/Components/Carousel/carousel.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+type TCarousel = {
+    default_page_index?: number;
+    onChange?: (new_page_index: number) => void;
+    should_reset_carousel?: boolean;
+    pages: { title: string; component: (onNextClick: () => void) => JSX.Element }[];
+};
+
+const Carousel = ({ default_page_index, onChange, should_reset_carousel, pages }: TCarousel) => {
+    const [current_index, setCurrentIndex] = React.useState(default_page_index ?? 0);
+
+    const pages_length = pages.length;
+
+    const onNextClick = () => setCurrentIndex((current_index + 1) % pages_length);
+    const onPrevClick = () => setCurrentIndex((current_index - 1 + pages_length) % pages_length);
+    const onPageChange = () => onChange?.(current_index);
+
+    React.useEffect(() => {
+        if (should_reset_carousel) setCurrentIndex(0);
+    }, [should_reset_carousel]);
+
+    return (
+        <ul className='carousel'>
+            {pages.map(({ title, component }) => (
+                <li
+                    className='carousel__item'
+                    style={{ transform: `translateX(-${current_index * 100}%)` }}
+                    key={title}
+                    onClick={onPageChange}
+                >
+                    {component(current_index ? onPrevClick : onNextClick)}
+                </li>
+            ))}
+        </ul>
+    );
+};
+
+export default Carousel;

--- a/packages/trader/src/AppV2/Components/Carousel/carousel.tsx
+++ b/packages/trader/src/AppV2/Components/Carousel/carousel.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 type TCarousel = {
     default_page_index?: number;
     onChange?: (new_page_index: number) => void;
-    pages: { title: string; component: (onNextClick: () => void) => JSX.Element }[];
+    pages: { id: string; component: (onNextClick: () => void) => JSX.Element }[];
     should_reset_carousel?: boolean;
 };
 
@@ -22,11 +22,11 @@ const Carousel = ({ default_page_index, onChange, pages, should_reset_carousel }
 
     return (
         <ul className='carousel'>
-            {pages.map(({ title, component }) => (
+            {pages.map(({ component, id }) => (
                 <li
                     className='carousel__item'
                     style={{ transform: `translateX(-${current_index * 100}%)` }}
-                    key={title}
+                    key={id}
                     onClick={onPageChange}
                 >
                     {component(current_index ? onPrevClick : onNextClick)}

--- a/packages/trader/src/AppV2/Components/Carousel/carousel.tsx
+++ b/packages/trader/src/AppV2/Components/Carousel/carousel.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 type TCarousel = {
     default_page_index?: number;
     onChange?: (new_page_index: number) => void;
-    pages: { id: string; component: (onNextClick: () => void) => JSX.Element }[];
+    pages: { id: number; component: (onNextClick: () => void) => JSX.Element }[];
     should_reset_carousel?: boolean;
 };
 

--- a/packages/trader/src/AppV2/Components/Carousel/carousel.tsx
+++ b/packages/trader/src/AppV2/Components/Carousel/carousel.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 type TCarousel = {
     default_page_index?: number;
     onChange?: (new_page_index: number) => void;
-    should_reset_carousel?: boolean;
     pages: { title: string; component: (onNextClick: () => void) => JSX.Element }[];
+    should_reset_carousel?: boolean;
 };
 
-const Carousel = ({ default_page_index, onChange, should_reset_carousel, pages }: TCarousel) => {
+const Carousel = ({ default_page_index, onChange, pages, should_reset_carousel }: TCarousel) => {
     const [current_index, setCurrentIndex] = React.useState(default_page_index ?? 0);
 
     const pages_length = pages.length;

--- a/packages/trader/src/AppV2/Components/Carousel/index.ts
+++ b/packages/trader/src/AppV2/Components/Carousel/index.ts
@@ -1,0 +1,4 @@
+import './carousel.scss';
+import Carousel from './carousel';
+
+export default Carousel;

--- a/packages/trader/src/AppV2/Components/PurchaseButton/__tests__/purchase-button.spec.tsx
+++ b/packages/trader/src/AppV2/Components/PurchaseButton/__tests__/purchase-button.spec.tsx
@@ -9,10 +9,10 @@ import ModulesProvider from 'Stores/Providers/modules-providers';
 import PurchaseButton from '../purchase-button';
 
 describe('PositionsContent', () => {
-    let defaultMockStore: ReturnType<typeof mockStore>;
+    let default_mock_store: ReturnType<typeof mockStore>;
 
     beforeEach(() => {
-        defaultMockStore = mockStore({
+        default_mock_store = mockStore({
             portfolio: {
                 all_positions: [
                     {
@@ -154,9 +154,9 @@ describe('PositionsContent', () => {
 
     const mockPurchaseButton = () => {
         render(
-            <TraderProviders store={defaultMockStore}>
+            <TraderProviders store={default_mock_store}>
                 <ReportsStoreProvider>
-                    <ModulesProvider store={defaultMockStore}>
+                    <ModulesProvider store={default_mock_store}>
                         <PurchaseButton />
                     </ModulesProvider>
                 </ReportsStoreProvider>
@@ -179,31 +179,31 @@ describe('PositionsContent', () => {
 
         const purchase_button = screen.getAllByRole('button')[0];
         expect(purchase_button).not.toHaveClass('purchase-button--loading');
-        expect(defaultMockStore.modules.trade.onPurchase).not.toBeCalled();
+        expect(default_mock_store.modules.trade.onPurchase).not.toBeCalled();
         expect(screen.queryByTestId('button-loader')).not.toBeInTheDocument();
 
         userEvent.click(purchase_button);
 
         expect(purchase_button).toHaveClass('purchase-button--loading');
-        expect(defaultMockStore.modules.trade.onPurchase).toBeCalled();
+        expect(default_mock_store.modules.trade.onPurchase).toBeCalled();
         expect(screen.getByTestId('button-loader')).toBeInTheDocument();
     });
 
     it('should disable the button if one of the prop is false (is_trade_enabled, is_proposal_empty, !info.id, is_purchase_enabled): button should have a specific attribute and if user clicks on it onPurchase will not be called', () => {
-        defaultMockStore.modules.trade.is_purchase_enabled = false;
+        default_mock_store.modules.trade.is_purchase_enabled = false;
         mockPurchaseButton();
 
         const purchase_button = screen.getAllByRole('button')[0];
         expect(purchase_button).toBeDisabled();
-        expect(defaultMockStore.modules.trade.onPurchase).not.toBeCalled();
+        expect(default_mock_store.modules.trade.onPurchase).not.toBeCalled();
 
         userEvent.click(purchase_button);
 
-        expect(defaultMockStore.modules.trade.onPurchase).not.toBeCalled();
+        expect(default_mock_store.modules.trade.onPurchase).not.toBeCalled();
     });
 
     it('should render only one button if trade_types have only one field', () => {
-        defaultMockStore.modules.trade.trade_types = {
+        default_mock_store.modules.trade.trade_types = {
             CALL: 'Rise',
         };
         mockPurchaseButton();
@@ -214,15 +214,15 @@ describe('PositionsContent', () => {
     });
 
     it('should render sell button for Accumulators contract if there is an open Accumulators contract; if user clicks on it - onClickSell should be called', () => {
-        defaultMockStore.modules.trade.has_open_accu_contract = true;
-        defaultMockStore.modules.trade.is_accumulator = true;
+        default_mock_store.modules.trade.has_open_accu_contract = true;
+        default_mock_store.modules.trade.is_accumulator = true;
         mockPurchaseButton();
 
         const sell_button = screen.getByText('Sell');
         expect(sell_button).toBeInTheDocument();
-        expect(defaultMockStore.portfolio.onClickSell).not.toBeCalled();
+        expect(default_mock_store.portfolio.onClickSell).not.toBeCalled();
 
         userEvent.click(sell_button);
-        expect(defaultMockStore.portfolio.onClickSell).toBeCalled();
+        expect(default_mock_store.portfolio.onClickSell).toBeCalled();
     });
 });

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/__tests__/allow-equals.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/__tests__/allow-equals.spec.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mockStore } from '@deriv/stores';
+import TraderProviders from '../../../../../trader-providers';
+import { ReportsStoreProvider } from '../../../../../../../reports/src/Stores/useReportsStores';
+import ModulesProvider from 'Stores/Providers/modules-providers';
+import { hasCallPutEqual, hasDurationForCallPutEqual } from 'Stores/Modules/Trading/Helpers/allow-equals';
+import AllowEquals from '../allow-equals';
+
+jest.mock('Stores/Modules/Trading/Helpers/allow-equals', () => ({
+    ...jest.requireActual('Stores/Modules/Trading/Helpers/allow-equals'),
+    hasCallPutEqual: jest.fn(() => true),
+    hasDurationForCallPutEqual: jest.fn(() => true),
+}));
+
+const title = 'Allow equals.';
+const mediaQueryList = {
+    matches: true,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+};
+
+window.matchMedia = jest.fn().mockImplementation(() => mediaQueryList);
+
+describe('AllowEquals', () => {
+    let default_mock_store: ReturnType<typeof mockStore>;
+
+    beforeEach(() => {
+        default_mock_store = mockStore({});
+    });
+
+    const mockAllowEquals = () => {
+        return (
+            <TraderProviders store={default_mock_store}>
+                <ReportsStoreProvider>
+                    <ModulesProvider store={default_mock_store}>
+                        <AllowEquals is_minimized />
+                    </ModulesProvider>
+                </ReportsStoreProvider>
+            </TraderProviders>
+        );
+    };
+
+    it('should not render component if hasCallPutEqual return false', () => {
+        (hasCallPutEqual as jest.Mock).mockReturnValueOnce(false);
+        const { container } = render(mockAllowEquals());
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should not render component if hasDurationForCallPutEqual return false', () => {
+        (hasDurationForCallPutEqual as jest.Mock).mockReturnValueOnce(false);
+        const { container } = render(mockAllowEquals());
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('should render component with correct input value if is_equal is 0', () => {
+        render(mockAllowEquals());
+
+        expect(screen.getByText(title)).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toHaveValue('-');
+    });
+
+    it('should render component with correct input value if is_equal is 1', () => {
+        default_mock_store.modules.trade.is_equal = 1;
+        render(mockAllowEquals());
+
+        expect(screen.getByText(title)).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toHaveValue('Enabled');
+    });
+
+    it('should show ActionSheet if user clicks on input', () => {
+        render(mockAllowEquals());
+
+        userEvent.click(screen.getByRole('textbox'));
+
+        expect(screen.getByRole('dialog')).toHaveAttribute('data-state', 'open');
+    });
+
+    it('should call onChange function if user opens ActionSheet, changes ToggleSwitch and clicks on "Save" button', () => {
+        render(mockAllowEquals());
+
+        userEvent.click(screen.getByRole('textbox'));
+
+        const [toggle_switch_button, save_button] = screen.getAllByRole('button');
+        expect(toggle_switch_button).toHaveAttribute('aria-pressed', 'false');
+        userEvent.click(toggle_switch_button);
+        expect(toggle_switch_button).toHaveAttribute('aria-pressed', 'true');
+
+        userEvent.click(save_button);
+        expect(default_mock_store.modules.trade.onChange).toBeCalled();
+    });
+});

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.scss
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.scss
@@ -2,7 +2,7 @@ $HANDLEBAR_HEIGHT: var(--core-size-1000);
 $HEADER_TITLE_HEIGHT: var(--core-size-3200);
 $FOOTER_BUTTON_HEIGHT: var(--core-size-4000);
 
-.trade-param {
+.allow-equals {
     &__wrapper {
         height: calc(40vh - $HANDLEBAR_HEIGHT - $HEADER_TITLE_HEIGHT - $FOOTER_BUTTON_HEIGHT);
 

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.scss
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.scss
@@ -1,0 +1,11 @@
+.trade-param {
+    &__wrapper {
+        height: calc(40vh - var(--core-spacing-1000) - var(--core-spacing-3200) - var(--core-spacing-4000));
+    }
+
+    &__content {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+}

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.scss
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.scss
@@ -1,11 +1,34 @@
 .trade-param {
     &__wrapper {
         height: calc(40vh - var(--core-spacing-1000) - var(--core-spacing-3200) - var(--core-spacing-4000));
+
+        &--definition {
+            height: calc(40vh - var(--core-spacing-1000) - var(--core-spacing-3200));
+        }
     }
 
     &__content {
         display: flex;
         justify-content: space-between;
         align-items: center;
+    }
+}
+
+.carousel {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: hidden;
+
+    &__item {
+        width: 100vw;
+        min-width: 100vw;
+        transition: transform 0.5s ease-in-out;
+    }
+
+    .icon--left {
+        .quill-action-sheet--title--icon {
+            right: unset;
+            left: 0;
+        }
     }
 }

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.scss
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.scss
@@ -1,5 +1,8 @@
 .trade-param {
     &__wrapper {
+        // var(--core-spacing-1000) - HandleBar height
+        // var(--core-spacing-3200) - Header height
+        // var(--core-spacing-4000) - Footer height
         height: calc(40vh - var(--core-spacing-1000) - var(--core-spacing-3200) - var(--core-spacing-4000));
 
         &--definition {
@@ -11,24 +14,5 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-    }
-}
-
-.carousel {
-    display: flex;
-    flex-wrap: nowrap;
-    overflow-x: hidden;
-
-    &__item {
-        width: 100vw;
-        min-width: 100vw;
-        transition: transform 0.5s ease-in-out;
-    }
-
-    .icon--left {
-        .quill-action-sheet--title--icon {
-            right: unset;
-            left: 0;
-        }
     }
 }

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.scss
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.scss
@@ -1,12 +1,13 @@
+$HANDLEBAR_HEIGHT: var(--core-size-1000);
+$HEADER_TITLE_HEIGHT: var(--core-size-3200);
+$FOOTER_BUTTON_HEIGHT: var(--core-size-4000);
+
 .trade-param {
     &__wrapper {
-        // var(--core-spacing-1000) - HandleBar height
-        // var(--core-spacing-3200) - Header height
-        // var(--core-spacing-4000) - Footer height
-        height: calc(40vh - var(--core-spacing-1000) - var(--core-spacing-3200) - var(--core-spacing-4000));
+        height: calc(40vh - $HANDLEBAR_HEIGHT - $HEADER_TITLE_HEIGHT - $FOOTER_BUTTON_HEIGHT);
 
         &--definition {
-            height: calc(40vh - var(--core-spacing-1000) - var(--core-spacing-3200));
+            height: calc(40vh - $HANDLEBAR_HEIGHT - $HEADER_TITLE_HEIGHT);
         }
     }
 

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { observer } from 'mobx-react';
 import clsx from 'clsx';
 import { ActionSheet, ToggleSwitch, Text, TextField } from '@deriv-com/quill-ui';
-import { LabelPairedCircleInfoMdRegularIcon } from '@deriv/quill-icons';
+import { LabelPairedArrowLeftMdRegularIcon, LabelPairedCircleInfoMdRegularIcon } from '@deriv/quill-icons';
 import { Localize, localize } from '@deriv/translations';
 import { hasCallPutEqual, hasDurationForCallPutEqual } from 'Stores/Modules/Trading/Helpers/allow-equals';
 import { useTraderStore } from 'Stores/useTraderStores';
@@ -17,6 +17,7 @@ const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
 
     const [is_open, setIsOpen] = React.useState(false);
     const [is_allow_equal_enabled, setIsAllowEqualEnabled] = React.useState(!!is_equal);
+    const [current_index, setCurrentIndex] = React.useState(0);
 
     const has_callputequal_duration = hasDurationForCallPutEqual(
         contract_types_list,
@@ -26,17 +27,16 @@ const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
     const has_callputequal = hasCallPutEqual(contract_types_list);
     const has_allow_equals = (has_callputequal_duration || expiry_type === 'endtime') && has_callputequal;
 
-    const onInfoIconClick = () => {
-        // console.log('Info Icon clicked!');
-    };
+    const onInfoIconClick = () => setCurrentIndex(1);
+    const onArrowIconClick = () => setCurrentIndex(0);
     const onSaveButtonClick = () => {
         if (!!is_equal !== is_allow_equal_enabled)
             onChange({ target: { name: 'is_equal', value: Number(is_allow_equal_enabled) } });
     };
-
     const onActionSheetClose = () => {
         setIsOpen(false);
         setIsAllowEqualEnabled(!!is_equal);
+        setCurrentIndex(0);
     };
 
     React.useEffect(() => {
@@ -57,28 +57,46 @@ const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
             />
             <ActionSheet.Root isOpen={is_open} onClose={onActionSheetClose} position='left' expandable={false}>
                 <ActionSheet.Portal shouldCloseOnDrag>
-                    <ActionSheet.Header
-                        title={<Localize i18n_default_text='Allow equals' />}
-                        icon={<LabelPairedCircleInfoMdRegularIcon onClick={onInfoIconClick} />}
-                    />
-                    <ActionSheet.Content className='trade-param__wrapper'>
-                        <div className='trade-param__content'>
-                            <Text>
-                                <Localize i18n_default_text='Allow equals' />
-                            </Text>
-                            <ToggleSwitch
-                                checked={is_allow_equal_enabled}
-                                onChange={(is_enabled: boolean) => setIsAllowEqualEnabled(is_enabled)}
+                    <ul className='carousel'>
+                        <li className='carousel__item' style={{ transform: `translateX(-${current_index * 100}%)` }}>
+                            <ActionSheet.Header
+                                title={<Localize i18n_default_text='Allow equals' />}
+                                icon={<LabelPairedCircleInfoMdRegularIcon onClick={onInfoIconClick} />}
                             />
-                        </div>
-                    </ActionSheet.Content>
-                    <ActionSheet.Footer
-                        alignment='vertical'
-                        primaryAction={{
-                            content: <Localize i18n_default_text='Save' />,
-                            onAction: onSaveButtonClick,
-                        }}
-                    />
+                            <ActionSheet.Content className='trade-param__wrapper'>
+                                <div className='trade-param__content'>
+                                    <Text>
+                                        <Localize i18n_default_text='Allow equals' />
+                                    </Text>
+                                    <ToggleSwitch
+                                        checked={is_allow_equal_enabled}
+                                        onChange={(is_enabled: boolean) => setIsAllowEqualEnabled(is_enabled)}
+                                    />
+                                </div>
+                            </ActionSheet.Content>
+                            <ActionSheet.Footer
+                                alignment='vertical'
+                                primaryAction={{
+                                    content: <Localize i18n_default_text='Save' />,
+                                    onAction: onSaveButtonClick,
+                                }}
+                            />
+                        </li>
+                        <li className='carousel__item' style={{ transform: `translateX(-${current_index * 100}%)` }}>
+                            <ActionSheet.Header
+                                title={<Localize i18n_default_text='Allow equals' />}
+                                icon={<LabelPairedArrowLeftMdRegularIcon onClick={onArrowIconClick} />}
+                                className='icon--left'
+                            />
+                            <ActionSheet.Content className='trade-param__wrapper--definition'>
+                                <div className='trade-param__content'>
+                                    <Text>
+                                        <Localize i18n_default_text='Win payout if exit spot is also equal to entry spot.' />
+                                    </Text>
+                                </div>
+                            </ActionSheet.Content>
+                        </li>
+                    </ul>
                 </ActionSheet.Portal>
             </ActionSheet.Root>
         </React.Fragment>

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.tsx
@@ -45,7 +45,7 @@ const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
 
     const action_sheet_content = [
         {
-            id: 'first page',
+            id: 1,
             component: (onNextClick: () => void) => (
                 <React.Fragment>
                     <ActionSheet.Header
@@ -74,7 +74,7 @@ const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
             ),
         },
         {
-            id: 'second page',
+            id: 2,
             component: (onPrevClick: () => void) => (
                 <React.Fragment>
                     <ActionSheet.Header

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.tsx
@@ -52,8 +52,8 @@ const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
                         title={<Localize i18n_default_text='Allow equals' />}
                         icon={<LabelPairedCircleInfoMdRegularIcon onClick={onNextClick} />}
                     />
-                    <ActionSheet.Content className='trade-param__wrapper'>
-                        <div className='trade-param__content'>
+                    <ActionSheet.Content className='allow-equals__wrapper'>
+                        <div className='allow-equals__content'>
                             <Text>
                                 <Localize i18n_default_text='Allow equals' />
                             </Text>
@@ -82,8 +82,8 @@ const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
                         icon={<LabelPairedArrowLeftMdRegularIcon onClick={onPrevClick} />}
                         className='icon--left'
                     />
-                    <ActionSheet.Content className='trade-param__wrapper--definition'>
-                        <div className='trade-param__content'>
+                    <ActionSheet.Content className='allow-equals__wrapper--definition'>
+                        <div className='allow-equals__content'>
                             <Text>
                                 <Localize i18n_default_text='Win payout if exit spot is also equal to entry spot.' />
                             </Text>

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { observer } from 'mobx-react';
 import clsx from 'clsx';
-import { TextField } from '@deriv-com/quill-ui';
-import { localize } from '@deriv/translations';
+import { ActionSheet, ToggleSwitch, Text, TextField } from '@deriv-com/quill-ui';
+import { LabelPairedCircleInfoMdRegularIcon } from '@deriv/quill-icons';
+import { Localize, localize } from '@deriv/translations';
 import { hasCallPutEqual, hasDurationForCallPutEqual } from 'Stores/Modules/Trading/Helpers/allow-equals';
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -11,7 +12,12 @@ type TAllowEqualsProps = {
 };
 
 const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
-    const { contract_types_list, contract_start_type, duration_unit, expiry_type, is_equal } = useTraderStore();
+    const { contract_types_list, contract_start_type, duration_unit, expiry_type, is_equal, onChange } =
+        useTraderStore();
+
+    const [is_open, setIsOpen] = React.useState(false);
+    const [is_allow_equal_enabled, setIsAllowEqualEnabled] = React.useState(!!is_equal);
+
     const has_callputequal_duration = hasDurationForCallPutEqual(
         contract_types_list,
         duration_unit,
@@ -20,15 +26,62 @@ const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
     const has_callputequal = hasCallPutEqual(contract_types_list);
     const has_allow_equals = (has_callputequal_duration || expiry_type === 'endtime') && has_callputequal;
 
+    const onInfoIconClick = () => {
+        // console.log('Info Icon clicked!');
+    };
+    const onSaveButtonClick = () => {
+        if (!!is_equal !== is_allow_equal_enabled)
+            onChange({ target: { name: 'is_equal', value: Number(is_allow_equal_enabled) } });
+    };
+
+    const onActionSheetClose = () => {
+        setIsOpen(false);
+        setIsAllowEqualEnabled(!!is_equal);
+    };
+
+    React.useEffect(() => {
+        setIsAllowEqualEnabled(!!is_equal);
+    }, [is_equal]);
+
     if (!has_allow_equals) return null;
+
     return (
-        <TextField
-            variant='fill'
-            readOnly
-            label={localize('Allow equals')}
-            value={is_equal ? localize('Enabled') : '-'}
-            className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
-        />
+        <React.Fragment>
+            <TextField
+                variant='fill'
+                readOnly
+                label={localize('Allow equals')}
+                value={is_equal ? localize('Enabled') : '-'}
+                className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
+                onClick={() => setIsOpen(true)}
+            />
+            <ActionSheet.Root isOpen={is_open} onClose={onActionSheetClose} position='left' expandable={false}>
+                <ActionSheet.Portal shouldCloseOnDrag>
+                    <ActionSheet.Header
+                        title={<Localize i18n_default_text='Allow equals' />}
+                        icon={<LabelPairedCircleInfoMdRegularIcon onClick={onInfoIconClick} />}
+                    />
+                    <ActionSheet.Content className='trade-param__wrapper'>
+                        <div className='trade-param__content'>
+                            <Text>
+                                <Localize i18n_default_text='Allow equals' />
+                            </Text>
+                            <ToggleSwitch
+                                checked={is_allow_equal_enabled}
+                                onChange={(is_enabled: boolean) => setIsAllowEqualEnabled(is_enabled)}
+                            />
+                        </div>
+                    </ActionSheet.Content>
+                    <ActionSheet.Footer
+                        alignment='vertical'
+                        primaryAction={{
+                            content: <Localize i18n_default_text='Save' />,
+                            onAction: onSaveButtonClick,
+                        }}
+                    />
+                </ActionSheet.Portal>
+            </ActionSheet.Root>
+        </React.Fragment>
     );
 });
 

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.tsx
@@ -34,7 +34,7 @@ const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
     };
     const onActionSheetClose = () => {
         setIsOpen(false);
-        //TODO: check if we need these 2 resetting below after latest Quill Action sheet changes will be in our branch
+        //TODO: check if we need these 2 resets below after latest Quill Action sheet changes will be in our branch
         setIsAllowEqualEnabled(!!is_equal);
         setShouldResetCarousel(true);
     };
@@ -45,7 +45,7 @@ const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
 
     const action_sheet_content = [
         {
-            title: 'first page',
+            id: 'first page',
             component: (onNextClick: () => void) => (
                 <React.Fragment>
                     <ActionSheet.Header
@@ -74,7 +74,7 @@ const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
             ),
         },
         {
-            title: 'second page',
+            id: 'second page',
             component: (onPrevClick: () => void) => (
                 <React.Fragment>
                     <ActionSheet.Header

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/allow-equals.tsx
@@ -105,7 +105,7 @@ const AllowEquals = observer(({ is_minimized }: TAllowEqualsProps) => {
             <TextField
                 variant='fill'
                 readOnly
-                label={localize('Allow equals')}
+                label={<Localize i18n_default_text='Allow equals.' />}
                 value={is_equal ? localize('Enabled') : '-'}
                 className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
                 onClick={() => setIsOpen(true)}

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/index.ts
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/index.ts
@@ -1,3 +1,4 @@
+import './allow-equals.scss';
 import AllowEquals from './allow-equals';
 
 export default AllowEquals;

--- a/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Barrier/barrier.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { observer } from 'mobx-react';
 import { TextField } from '@deriv-com/quill-ui';
-import { localize } from '@deriv/translations';
+import { Localize } from '@deriv/translations';
 import { useTraderStore } from 'Stores/useTraderStores';
 
 type TDurationProps = {
@@ -15,7 +15,7 @@ const Barrier = observer(({ is_minimized }: TDurationProps) => {
         <TextField
             variant='fill'
             readOnly
-            label={localize('Barrier')}
+            label={<Localize i18n_default_text='Barrier' />}
             value={barrier_1}
             className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
         />

--- a/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Duration/duration.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { observer } from 'mobx-react';
 import { TextField } from '@deriv-com/quill-ui';
 import { getUnitMap } from '@deriv/shared';
-import { localize } from '@deriv/translations';
+import { Localize } from '@deriv/translations';
 import { useTraderStore } from 'Stores/useTraderStores';
 
 type TDurationProps = {
@@ -19,7 +19,7 @@ const Duration = observer(({ is_minimized }: TDurationProps) => {
         <TextField
             variant='fill'
             readOnly
-            label={localize('Duration')}
+            label={<Localize i18n_default_text='Duration' />}
             value={`${duration} ${duration_unit_text}`}
             className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
         />

--- a/packages/trader/src/AppV2/Components/TradeParameters/GrowthRate/growth-rate.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/GrowthRate/growth-rate.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { observer } from 'mobx-react';
 import { TextField } from '@deriv-com/quill-ui';
-import { localize } from '@deriv/translations';
+import { Localize } from '@deriv/translations';
 import { useTraderStore } from 'Stores/useTraderStores';
 import { getGrowthRatePercentage } from '@deriv/shared';
 
@@ -16,7 +16,7 @@ const GrowthRate = observer(({ is_minimized }: TGrowthRateProps) => {
         <TextField
             variant='fill'
             readOnly
-            label={localize('Growth rate')}
+            label={<Localize i18n_default_text='Growth rate' />}
             value={`${getGrowthRatePercentage(growth_rate)}%`}
             className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
             disabled={has_open_accu_contract}

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { observer } from 'mobx-react';
 import clsx from 'clsx';
 import { CaptionText, Text, TextField } from '@deriv-com/quill-ui';
-import { Localize, localize } from '@deriv/translations';
+import { Localize } from '@deriv/translations';
 import { useTraderStore } from 'Stores/useTraderStores';
 
 type TLastDigitSelectorProps = {
@@ -23,7 +23,7 @@ const LastDigitPrediction = observer(({ is_minimized }: TLastDigitSelectorProps)
             <TextField
                 variant='fill'
                 readOnly
-                label={localize('Last digit prediction')}
+                label={<Localize i18n_default_text='Last digit prediction' />}
                 value={last_digit}
                 className={clsx('trade-params__option', 'trade-params__option--minimized')}
             />

--- a/packages/trader/src/AppV2/Components/TradeParameters/Multiplier/multiplier.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Multiplier/multiplier.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { observer } from 'mobx-react';
 import { TextField } from '@deriv-com/quill-ui';
-import { localize } from '@deriv/translations';
+import { Localize } from '@deriv/translations';
 import { useTraderStore } from 'Stores/useTraderStores';
 
 type TMultiplierProps = {
@@ -15,7 +15,7 @@ const Multiplier = observer(({ is_minimized }: TMultiplierProps) => {
         <TextField
             variant='fill'
             readOnly
-            label={localize('Multiplier')}
+            label={<Localize i18n_default_text='Multiplier' />}
             value={`x${multiplier}`}
             className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
         />

--- a/packages/trader/src/AppV2/Components/TradeParameters/PayoutPerPoint/payout-per-point.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/PayoutPerPoint/payout-per-point.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { observer } from 'mobx-react';
 import { TextField } from '@deriv-com/quill-ui';
-import { localize } from '@deriv/translations';
+import { Localize } from '@deriv/translations';
 import { useTraderStore } from 'Stores/useTraderStores';
 import { getCurrencyDisplayCode } from '@deriv/shared';
 import { Skeleton } from '@deriv/components';
@@ -27,7 +27,7 @@ const PayoutPerPoint = observer(({ is_minimized }: TPayoutPerPointProps) => {
         <TextField
             variant='fill'
             readOnly
-            label={localize('Payout per point')}
+            label={<Localize i18n_default_text='Payout per point' />}
             value={`${payout_per_point} ${getCurrencyDisplayCode(currency)}`}
             className={classname}
         />

--- a/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/RiskManagement/risk-management.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import clsx from 'clsx';
 import { TextField } from '@deriv-com/quill-ui';
-import { localize } from '@deriv/translations';
+import { Localize, localize } from '@deriv/translations';
 
 type TRiskManagementProps = {
     is_minimized?: boolean;
@@ -12,7 +12,7 @@ const RiskManagement = ({ is_minimized }: TRiskManagementProps) => {
         <TextField
             variant='fill'
             readOnly
-            label={localize('Risk Management')}
+            label={<Localize i18n_default_text='Risk Management' />}
             value={localize('Not set')}
             className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
         />

--- a/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Stake/stake.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { observer } from 'mobx-react';
 import { TextField } from '@deriv-com/quill-ui';
-import { localize } from '@deriv/translations';
+import { Localize } from '@deriv/translations';
 import { useTraderStore } from 'Stores/useTraderStores';
 import { getCurrencyDisplayCode } from '@deriv/shared';
 
@@ -28,7 +28,7 @@ const Stake = observer(({ is_minimized }: TStakeProps) => {
         <TextField
             variant='fill'
             readOnly
-            label={localize('Stake')}
+            label={<Localize i18n_default_text='Stake' />}
             value={`${amount} ${getCurrencyDisplayCode(currency)}`}
             className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
         />

--- a/packages/trader/src/AppV2/Components/TradeParameters/Strike/strike.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/Strike/strike.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { observer } from 'mobx-react';
 import { TextField } from '@deriv-com/quill-ui';
-import { localize } from '@deriv/translations';
+import { Localize } from '@deriv/translations';
 import clsx from 'clsx';
 import { useTraderStore } from 'Stores/useTraderStores';
 
@@ -15,7 +15,7 @@ const Strike = observer(({ is_minimized }: TStrikeProps) => {
         <TextField
             variant='fill'
             readOnly
-            label={localize('Strike price')}
+            label={<Localize i18n_default_text='Strike price' />}
             value={barrier_1}
             className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
         />

--- a/packages/trader/src/AppV2/Components/TradeParameters/TakeProfit/take-profit.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/TakeProfit/take-profit.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import { observer } from 'mobx-react';
 import { TextField } from '@deriv-com/quill-ui';
-import { localize } from '@deriv/translations';
+import { Localize, localize } from '@deriv/translations';
 import { useTraderStore } from 'Stores/useTraderStores';
 import { getCurrencyDisplayCode } from '@deriv/shared';
 
@@ -16,7 +16,7 @@ const TakeProfit = observer(({ is_minimized }: TTakeProfitProps) => {
         <TextField
             variant='fill'
             readOnly
-            label={localize('Take profit')}
+            label={<Localize i18n_default_text='Take profit' />}
             value={take_profit ? `${take_profit} ${getCurrencyDisplayCode(currency)}` : localize('Not set')}
             className={clsx('trade-params__option', is_minimized && 'trade-params__option--minimized')}
             disabled={has_open_accu_contract}

--- a/packages/trader/src/AppV2/Components/TradeParameters/TradeTypeTabs/__tests__/trade-type-tabs.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/TradeTypeTabs/__tests__/trade-type-tabs.spec.tsx
@@ -9,17 +9,17 @@ import ModulesProvider from 'Stores/Providers/modules-providers';
 import TradeTypeTabs from '../trade-type-tabs';
 
 describe('TradeTypeTabs', () => {
-    let defaultMockStore: ReturnType<typeof mockStore>;
+    let default_mock_store: ReturnType<typeof mockStore>;
 
     beforeEach(() => {
-        defaultMockStore = mockStore({});
+        default_mock_store = mockStore({});
     });
 
     const mockTradeTypeTabs = (props?: React.ComponentProps<typeof TradeTypeTabs>) => {
         return (
-            <TraderProviders store={defaultMockStore}>
+            <TraderProviders store={default_mock_store}>
                 <ReportsStoreProvider>
-                    <ModulesProvider store={defaultMockStore}>
+                    <ModulesProvider store={default_mock_store}>
                         <TradeTypeTabs {...props} />
                     </ModulesProvider>
                 </ReportsStoreProvider>
@@ -34,7 +34,7 @@ describe('TradeTypeTabs', () => {
     });
 
     it('should render correct tabs name for Vanillas', () => {
-        defaultMockStore.modules.trade.contract_type = TRADE_TYPES.VANILLA.CALL;
+        default_mock_store.modules.trade.contract_type = TRADE_TYPES.VANILLA.CALL;
         render(mockTradeTypeTabs({ is_minimized: true }));
 
         expect(screen.getByText('Call')).toBeInTheDocument();
@@ -44,16 +44,16 @@ describe('TradeTypeTabs', () => {
     });
 
     it('should call onChange function if user clicks on another tab and not call it if he clicks on the already chosen one', () => {
-        defaultMockStore.modules.trade.contract_type = TRADE_TYPES.TURBOS.LONG;
+        default_mock_store.modules.trade.contract_type = TRADE_TYPES.TURBOS.LONG;
         render(mockTradeTypeTabs());
 
         const current_tab = screen.getByText('Up');
         const another_tab = screen.getByText('Down');
-        expect(defaultMockStore.modules.trade.onChange).not.toBeCalled();
+        expect(default_mock_store.modules.trade.onChange).not.toBeCalled();
         userEvent.click(current_tab);
-        expect(defaultMockStore.modules.trade.onChange).not.toBeCalled();
+        expect(default_mock_store.modules.trade.onChange).not.toBeCalled();
 
         userEvent.click(another_tab);
-        expect(defaultMockStore.modules.trade.onChange).toBeCalled();
+        expect(default_mock_store.modules.trade.onChange).toBeCalled();
     });
 });

--- a/packages/trader/src/AppV2/Components/TradeParameters/__tests__/trade-parameters.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/__tests__/trade-parameters.spec.tsx
@@ -47,17 +47,17 @@ jest.mock('../LastDigitPrediction', () =>
 );
 
 describe('TradeParameters', () => {
-    let defaultMockStore: ReturnType<typeof mockStore>;
+    let default_mock_store: ReturnType<typeof mockStore>;
 
     beforeEach(() => {
-        defaultMockStore = mockStore({});
+        default_mock_store = mockStore({});
     });
 
     const mockTradeParameters = () => {
         return (
-            <TraderProviders store={defaultMockStore}>
+            <TraderProviders store={default_mock_store}>
                 <ReportsStoreProvider>
-                    <ModulesProvider store={defaultMockStore}>
+                    <ModulesProvider store={default_mock_store}>
                         <TradeParameters />
                     </ModulesProvider>
                 </ReportsStoreProvider>
@@ -66,7 +66,7 @@ describe('TradeParameters', () => {
     };
 
     it('should render correct trade params for Accumulators', () => {
-        defaultMockStore.modules.trade.contract_type = TRADE_TYPES.ACCUMULATOR;
+        default_mock_store.modules.trade.contract_type = TRADE_TYPES.ACCUMULATOR;
         render(mockTradeParameters());
 
         expect(screen.getByText(TRADE_PARAMS.GROWTH_RATE)).toBeInTheDocument();
@@ -77,7 +77,7 @@ describe('TradeParameters', () => {
     });
 
     it('should render correct trade params for Vanillas', () => {
-        defaultMockStore.modules.trade.contract_type = TRADE_TYPES.VANILLA.CALL;
+        default_mock_store.modules.trade.contract_type = TRADE_TYPES.VANILLA.CALL;
         render(mockTradeParameters());
 
         expect(screen.getByText(TRADE_PARAMS.TRADE_TYPE_TABS)).toBeInTheDocument();
@@ -88,7 +88,7 @@ describe('TradeParameters', () => {
     });
 
     it('should render correct trade params for Turbos', () => {
-        defaultMockStore.modules.trade.contract_type = TRADE_TYPES.TURBOS.LONG;
+        default_mock_store.modules.trade.contract_type = TRADE_TYPES.TURBOS.LONG;
         render(mockTradeParameters());
 
         expect(screen.getByText(TRADE_PARAMS.TRADE_TYPE_TABS)).toBeInTheDocument();
@@ -100,7 +100,7 @@ describe('TradeParameters', () => {
     });
 
     it('should render correct trade params for Multipliers', () => {
-        defaultMockStore.modules.trade.contract_type = TRADE_TYPES.MULTIPLIER;
+        default_mock_store.modules.trade.contract_type = TRADE_TYPES.MULTIPLIER;
         render(mockTradeParameters());
 
         expect(screen.getByText(TRADE_PARAMS.MULTIPLIER)).toBeInTheDocument();
@@ -111,7 +111,7 @@ describe('TradeParameters', () => {
     });
 
     it('should render correct trade params for Rise/Fall', () => {
-        defaultMockStore.modules.trade.contract_type = TRADE_TYPES.RISE_FALL;
+        default_mock_store.modules.trade.contract_type = TRADE_TYPES.RISE_FALL;
         render(mockTradeParameters());
 
         expect(screen.getByText(TRADE_PARAMS.DURATION)).toBeInTheDocument();
@@ -121,7 +121,7 @@ describe('TradeParameters', () => {
     });
 
     it('should render correct trade params for Higher/Lower', () => {
-        defaultMockStore.modules.trade.contract_type = TRADE_TYPES.HIGH_LOW;
+        default_mock_store.modules.trade.contract_type = TRADE_TYPES.HIGH_LOW;
         render(mockTradeParameters());
 
         expect(screen.getByText(TRADE_PARAMS.DURATION)).toBeInTheDocument();
@@ -131,7 +131,7 @@ describe('TradeParameters', () => {
     });
 
     it('should render correct trade params for Touch/No Touch', () => {
-        defaultMockStore.modules.trade.contract_type = TRADE_TYPES.TOUCH;
+        default_mock_store.modules.trade.contract_type = TRADE_TYPES.TOUCH;
         render(mockTradeParameters());
 
         expect(screen.getByText(TRADE_PARAMS.DURATION)).toBeInTheDocument();
@@ -141,7 +141,7 @@ describe('TradeParameters', () => {
     });
 
     it('should render correct trade params for Matches/Differs', () => {
-        defaultMockStore.modules.trade.contract_type = TRADE_TYPES.MATCH_DIFF;
+        default_mock_store.modules.trade.contract_type = TRADE_TYPES.MATCH_DIFF;
         render(mockTradeParameters());
 
         expect(screen.getByText(TRADE_PARAMS.LAST_DIGIT_PREDICTION)).toBeInTheDocument();
@@ -151,7 +151,7 @@ describe('TradeParameters', () => {
     });
 
     it('should render correct trade params for Even/Odd', () => {
-        defaultMockStore.modules.trade.contract_type = TRADE_TYPES.EVEN_ODD;
+        default_mock_store.modules.trade.contract_type = TRADE_TYPES.EVEN_ODD;
         render(mockTradeParameters());
 
         expect(screen.getByText(TRADE_PARAMS.DURATION)).toBeInTheDocument();
@@ -160,7 +160,7 @@ describe('TradeParameters', () => {
     });
 
     it('should render correct trade params for Over/Under', () => {
-        defaultMockStore.modules.trade.contract_type = TRADE_TYPES.OVER_UNDER;
+        default_mock_store.modules.trade.contract_type = TRADE_TYPES.OVER_UNDER;
         render(mockTradeParameters());
 
         expect(screen.getByText(TRADE_PARAMS.LAST_DIGIT_PREDICTION)).toBeInTheDocument();


### PR DESCRIPTION
## Changes:

1. Implemented Allow equals trade param functionality: added ActionSheet with ToggleSwitcher and Save button.
2. Implemented a reusable Carousel component
3. Added tests 

### Screenshots:

![Screenshot 2024-07-18 at 5 58 20 PM](https://github.com/user-attachments/assets/c647e30c-0cb4-483d-a141-40c94cd12fb9)
![Screenshot 2024-07-18 at 6 57 58 PM](https://github.com/user-attachments/assets/ae8c3592-bc10-489d-bd9e-acfb0f624574)

https://github.com/user-attachments/assets/7f2a1560-2a32-4571-9b67-e0074aa65196


