### PR TITLE
Maryia/DTRA-1491/test: last digit selector & current spot

### DIFF
--- a/packages/core/src/App/app.jsx
+++ b/packages/core/src/App/app.jsx
@@ -108,18 +108,17 @@ const AppWithoutTranslation = ({ root_store }) => {
         }
     }, [root_store.client.email]);
 
-    const getLoader = () => {
-        if (isDTraderV2())
-            return (
-                <Loading.DTraderV2
-                    initial_app_loading
-                    is_contract_details={location.pathname.startsWith('/contract/')}
-                    is_positions={location.pathname === routes.trader_positions}
-                    is_closed_tab={getPositionsV2TabIndexFromURL() === 1}
-                />
-            );
-        return <Loading />;
-    };
+    const getLoader = () =>
+        isDTraderV2() ? (
+            <Loading.DTraderV2
+                initial_app_loading
+                is_contract_details={location.pathname.startsWith('/contract/')}
+                is_positions={location.pathname === routes.trader_positions}
+                is_closed_tab={getPositionsV2TabIndexFromURL() === 1}
+            />
+        ) : (
+            <Loading />
+        );
 
     return (
         <>

--- a/packages/trader/src/AppV2/Components/CurrentSpot/__tests__/current-spot-display.spec.tsx
+++ b/packages/trader/src/AppV2/Components/CurrentSpot/__tests__/current-spot-display.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import CurrentSpotDisplay from '../current-spot-display';
 
 describe('CurrentSpotDisplay', () => {
@@ -25,17 +25,21 @@ describe('CurrentSpotDisplay', () => {
 
         expect(screen.getByText('Tick 2')).toBeInTheDocument();
     });
-    it('should update last digit upon spot update', () => {
+    it('should update last digit upon spot update', async () => {
         jest.useFakeTimers();
         const { rerender } = render(<CurrentSpotDisplay {...mocked_props} />);
         expect(screen.getByText(mocked_props.spot.slice(0, -1))).toBeInTheDocument();
 
         rerender(<CurrentSpotDisplay {...mocked_props} spot='389.49' />);
-        jest.advanceTimersByTime(240); // equal to total animation time
-        expect(screen.getByText('9')).toBeInTheDocument();
+        await waitFor(() => {
+            jest.advanceTimersByTime(240); // equal to total animation time
+            expect(screen.getByText('9')).toBeInTheDocument();
+        });
 
         rerender(<CurrentSpotDisplay {...mocked_props} spot='389.51' />);
-        jest.advanceTimersByTime(240); // equal to total animation time
-        expect(screen.getByText('1')).toBeInTheDocument();
+        await waitFor(() => {
+            jest.advanceTimersByTime(240); // equal to total animation time
+            expect(screen.getByText('1')).toBeInTheDocument();
+        });
     });
 });

--- a/packages/trader/src/AppV2/Components/CurrentSpot/__tests__/current-spot-display.spec.tsx
+++ b/packages/trader/src/AppV2/Components/CurrentSpot/__tests__/current-spot-display.spec.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CurrentSpotDisplay from '../current-spot-display';
+
+describe('CurrentSpotDisplay', () => {
+    const mocked_props = {
+        has_tick_count: false,
+        spot: '389.45',
+        tick: null,
+    };
+
+    it('should not render if spot prop is null', () => {
+        const { container } = render(<CurrentSpotDisplay {...mocked_props} spot={null} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+    it('should render spot value without tick count when spot prop is provided while tick={null} and has_tick_count={false}', () => {
+        render(<CurrentSpotDisplay {...mocked_props} />);
+
+        expect(screen.getByText(mocked_props.spot.slice(0, -1))).toBeInTheDocument();
+        expect(screen.getByText(mocked_props.spot.slice(-1))).toBeInTheDocument();
+        expect(screen.queryByText(/Tick/)).not.toBeInTheDocument();
+    });
+    it('should render tick count when tick prop is provided and has_tick_count={true}', () => {
+        render(<CurrentSpotDisplay {...mocked_props} tick={2} has_tick_count />);
+
+        expect(screen.getByText('Tick 2')).toBeInTheDocument();
+    });
+    it('should update last digit upon spot update', () => {
+        jest.useFakeTimers();
+        const { rerender } = render(<CurrentSpotDisplay {...mocked_props} />);
+        expect(screen.getByText(mocked_props.spot.slice(0, -1))).toBeInTheDocument();
+
+        rerender(<CurrentSpotDisplay {...mocked_props} spot='389.49' />);
+        jest.advanceTimersByTime(240); // equal to total animation time
+        expect(screen.getByText('9')).toBeInTheDocument();
+
+        rerender(<CurrentSpotDisplay {...mocked_props} spot='389.51' />);
+        jest.advanceTimersByTime(240); // equal to total animation time
+        expect(screen.getByText('1')).toBeInTheDocument();
+    });
+});

--- a/packages/trader/src/AppV2/Components/CurrentSpot/__tests__/current-spot.spec.tsx
+++ b/packages/trader/src/AppV2/Components/CurrentSpot/__tests__/current-spot.spec.tsx
@@ -1,0 +1,315 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { mockContractInfo, TContractStore } from '@deriv/shared';
+import { mockStore } from '@deriv/stores';
+import TraderProviders from '../../../../trader-providers';
+import ModulesProvider from 'Stores/Providers/modules-providers';
+import CurrentSpot from '../current-spot';
+
+const mocked_now = Math.floor(Date.now() / 1000);
+
+describe('CurrentSpot', () => {
+    let default_mock_store: ReturnType<typeof mockStore>;
+    const tick_data = {
+        ask: 405.76,
+        bid: 405.56,
+        epoch: mocked_now,
+        id: 'f90a93f8-965a-28ab-a830-6253bff4cc98',
+        pip_size: 2,
+        quote: 405.66,
+        symbol: '1HZ100V',
+    };
+    const ongoing_contract_info = mockContractInfo({
+        barrier: '0',
+        contract_id: 250136683588,
+        contract_type: 'DIGITEVEN',
+        date_expiry: mocked_now + 1000,
+        date_start: 1721636565,
+        entry_tick: 389.39,
+        is_expired: 0,
+        is_path_dependent: 0,
+        is_sold: 0,
+        profit: -0.39,
+        status: 'open',
+        tick_count: 10,
+        tick_stream: [
+            {
+                epoch: 1721636566,
+                tick: 389.39,
+                tick_display_value: '389.39',
+            },
+            {
+                epoch: 1721636567,
+                tick: 389.37,
+                tick_display_value: '389.37',
+            },
+            {
+                epoch: 1721636568,
+                tick: 389.4,
+                tick_display_value: '389.40',
+            },
+        ],
+        underlying: '1HZ100V',
+    });
+    const closed_contract_info = mockContractInfo({
+        barrier: '0',
+        contract_id: 250136653148,
+        contract_type: 'DIGITODD',
+        date_expiry: 1721636554,
+        date_start: 1721636544,
+        entry_tick: 389.32,
+        exit_tick_time: 1721636554,
+        is_expired: 1,
+        is_path_dependent: 0,
+        is_sold: 1,
+        profit: -10,
+        sell_time: 1721636554,
+        status: 'lost',
+        tick_count: 10,
+        tick_stream: [
+            {
+                epoch: 1721636545,
+                tick: 389.32,
+                tick_display_value: '389.32',
+            },
+            {
+                epoch: 1721636546,
+                tick: 389.35,
+                tick_display_value: '389.35',
+            },
+            {
+                epoch: 1721636547,
+                tick: 389.36,
+                tick_display_value: '389.36',
+            },
+            {
+                epoch: 1721636548,
+                tick: 389.43,
+                tick_display_value: '389.43',
+            },
+            {
+                epoch: 1721636549,
+                tick: 389.5,
+                tick_display_value: '389.50',
+            },
+            {
+                epoch: 1721636550,
+                tick: 389.39,
+                tick_display_value: '389.39',
+            },
+            {
+                epoch: 1721636551,
+                tick: 389.31,
+                tick_display_value: '389.31',
+            },
+            {
+                epoch: 1721636552,
+                tick: 389.33,
+                tick_display_value: '389.33',
+            },
+            {
+                epoch: 1721636553,
+                tick: 389.43,
+                tick_display_value: '389.43',
+            },
+            {
+                epoch: 1721636554,
+                tick: 389.38,
+                tick_display_value: '389.38',
+            },
+        ],
+        underlying: '1HZ100V',
+    });
+    const ongoing_contract = {
+        digits_info: {
+            1721636566: {
+                digit: 9,
+                spot: '389.39',
+            },
+            1721636567: {
+                digit: 7,
+                spot: '389.37',
+            },
+            1721636568: {
+                digit: 0,
+                spot: '389.30',
+            },
+            1721636569: {
+                digit: 7,
+                spot: '389.27',
+            },
+            1721636570: {
+                digit: 6,
+                spot: '389.26',
+            },
+            1721636571: {
+                digit: 8,
+                spot: '389.18',
+            },
+            1721636572: {
+                digit: 7,
+                spot: '389.27',
+            },
+            1721636573: {
+                digit: 8,
+                spot: '389.38',
+            },
+            1721636574: {
+                digit: 7,
+                spot: '389.47',
+            },
+            [mocked_now + 1000]: {
+                digit: 4,
+                spot: '389.44',
+            },
+        },
+        display_status: 'purchased',
+        is_digit_contract: true,
+        is_ended: false,
+        contract_info: ongoing_contract_info,
+    } as unknown as TContractStore;
+    const closed_contract = {
+        digits_info: {
+            1721636545: {
+                digit: 2,
+                spot: '389.32',
+            },
+            1721636546: {
+                digit: 5,
+                spot: '389.35',
+            },
+            1721636547: {
+                digit: 6,
+                spot: '389.36',
+            },
+            1721636548: {
+                digit: 3,
+                spot: '389.43',
+            },
+            1721636549: {
+                digit: 0,
+                spot: '389.50',
+            },
+            1721636550: {
+                digit: 9,
+                spot: '389.39',
+            },
+            1721636551: {
+                digit: 1,
+                spot: '389.31',
+            },
+            1721636552: {
+                digit: 3,
+                spot: '389.33',
+            },
+            1721636553: {
+                digit: 3,
+                spot: '389.43',
+            },
+            1721636554: {
+                digit: 8,
+                spot: '389.38',
+            },
+        },
+        display_status: 'lost',
+        is_digit_contract: true,
+        is_ended: true,
+        contract_info: closed_contract_info,
+    } as unknown as TContractStore;
+
+    beforeEach(() => {
+        default_mock_store = mockStore({
+            modules: {
+                trade: {
+                    digit_tick: null,
+                    symbol: '1HZ100V',
+                    setDigitTick: jest.fn(),
+                },
+            },
+        });
+    });
+
+    const mockCurrentSpot = (store = default_mock_store) => (
+        <TraderProviders store={store}>
+            <ModulesProvider store={store}>
+                <CurrentSpot />
+            </ModulesProvider>
+        </TraderProviders>
+    );
+
+    it('should render skeleton loader if has no tick data to display', () => {
+        render(mockCurrentSpot());
+
+        expect(screen.getByTestId('dt_skeleton')).toBeInTheDocument();
+    });
+    it('should render spot (tick.quote) without tick count if has tick data but no contract data', () => {
+        default_mock_store.modules.trade.digit_tick = tick_data;
+        render(mockCurrentSpot());
+
+        expect(screen.getByText('405.6')).toBeInTheDocument();
+        expect(screen.getByText('6')).toBeInTheDocument();
+    });
+    it('should render the latest tick_stream spot from last contract info together with tick count when has last contract data', () => {
+        default_mock_store.modules.trade.digit_tick = tick_data;
+        default_mock_store.contract_trade.last_contract = ongoing_contract;
+        default_mock_store.contract_trade.prev_contract = closed_contract;
+        render(mockCurrentSpot());
+
+        const spot = ongoing_contract.contract_info.tick_stream?.[2].tick_display_value as string;
+        expect(screen.getByText('Tick 3')).toBeInTheDocument();
+        expect(screen.getByText(spot.slice(0, -1))).toBeInTheDocument();
+        expect(screen.getByText(spot.slice(-1))).toBeInTheDocument();
+    });
+    it('should render 2 tick counts for animation purposes when next contract is opened while previous contract is ongoing', () => {
+        const tick_stream = ongoing_contract.contract_info.tick_stream as { [key: string]: unknown }[];
+
+        default_mock_store.modules.trade.digit_tick = tick_data;
+        default_mock_store.contract_trade.prev_contract = {
+            ...ongoing_contract,
+            contract_info: {
+                ...ongoing_contract_info,
+                contract_id: 250136683587,
+                tick_stream: [...tick_stream, ...tick_stream],
+            },
+        };
+        default_mock_store.contract_trade.last_contract = ongoing_contract;
+        const { rerender } = render(mockCurrentSpot());
+
+        expect(screen.getByText('Tick 3')).toBeInTheDocument();
+        const spot = tick_stream?.[2].tick_display_value as string;
+        expect(screen.getByText(spot.slice(0, -1))).toBeInTheDocument();
+        expect(screen.getByText(spot.slice(-1))).toBeInTheDocument();
+
+        rerender(
+            mockCurrentSpot({
+                ...default_mock_store,
+                contract_trade: {
+                    ...default_mock_store.contract_trade,
+                    prev_contract: ongoing_contract,
+                    last_contract: {
+                        ...ongoing_contract,
+                        contract_info: {
+                            ...ongoing_contract_info,
+                            contract_id: 250136683589,
+                            tick_stream: tick_stream.slice(0, 1),
+                        },
+                    },
+                },
+            })
+        );
+        expect(screen.getByText('Tick 1')).toBeInTheDocument();
+        expect(screen.getByText('Tick 3')).toBeInTheDocument();
+        const new_spot = tick_stream?.[0].tick_display_value as string;
+        expect(screen.getByText(new_spot.slice(0, -1))).toBeInTheDocument();
+        expect(screen.getByText(new_spot.slice(-1))).toBeInTheDocument();
+    });
+    it('should render spot (tick.quote) without tick count if last contract is closed', () => {
+        default_mock_store.modules.trade.digit_tick = tick_data;
+        default_mock_store.contract_trade.last_contract = closed_contract;
+        render(mockCurrentSpot());
+
+        expect(screen.queryByText('Tick 10')).not.toBeInTheDocument();
+        expect(screen.getByText('405.6')).toBeInTheDocument();
+        expect(screen.getByText('6')).toBeInTheDocument();
+    });
+});

--- a/packages/trader/src/AppV2/Components/CurrentSpot/current-spot-display.tsx
+++ b/packages/trader/src/AppV2/Components/CurrentSpot/current-spot-display.tsx
@@ -15,6 +15,7 @@ const ACTIONS = {
     DEC: 'decrement',
     ADD10: 'add10',
 } as const;
+const TOTAL_ANIMATION_TIME = 240;
 
 const CurrentSpotDisplay = ({ has_tick_count, spot, tick }: TCurrentSpotDisplayProps) => {
     const last_digit = Number(spot?.slice(-1));
@@ -31,7 +32,12 @@ const CurrentSpotDisplay = ({ has_tick_count, spot, tick }: TCurrentSpotDisplayP
     const spin_timeout_id = React.useRef<ReturnType<typeof setTimeout>>();
     const spinning_wrapper_ref = React.useRef<HTMLDivElement>(null);
 
-    const spinLastDigit = (action: string, interval_ms: number, start: number, end: number) => {
+    const spinLastDigit = (
+        action: typeof ACTIONS[keyof typeof ACTIONS],
+        interval_ms: number,
+        start: number,
+        end: number
+    ) => {
         clearInterval(spin_interval_id.current);
         const interval_id = setInterval(() => {
             if (action === ACTIONS.INC && last_digit_ref.current < end) {
@@ -54,7 +60,7 @@ const CurrentSpotDisplay = ({ has_tick_count, spot, tick }: TCurrentSpotDisplayP
         if (isNaN(prev_last_digit) || isNaN(last_digit) || !spot) return;
 
         const diff = Math.abs(Number(prev_last_digit) - last_digit);
-        const timeout_speed = diff > 0 ? Math.floor(240 / diff) : 240;
+        const timeout_speed = diff > 0 ? Math.floor(TOTAL_ANIMATION_TIME / diff) : TOTAL_ANIMATION_TIME;
         const should_increment = Number(prev_last_digit) <= last_digit;
 
         spinning_wrapper_ref.current?.style.setProperty('--animation-time', `${timeout_speed}ms`);
@@ -69,10 +75,10 @@ const CurrentSpotDisplay = ({ has_tick_count, spot, tick }: TCurrentSpotDisplayP
             setShouldEnterFromTop(false);
             setShouldEnterFromBottom(false);
             setDisplayedLastDigit(last_digit_ref.current % 10);
-        }, 240); // equal to total animation time
+        }, TOTAL_ANIMATION_TIME); // equal to total animation time
 
         const getAction = () => {
-            let action: string = ACTIONS.ADD10;
+            let action: typeof ACTIONS[keyof typeof ACTIONS] = ACTIONS.ADD10;
             if (Number(prev_last_digit) < last_digit) {
                 action = ACTIONS.INC;
             } else if (Number(prev_last_digit) > last_digit) {
@@ -99,7 +105,7 @@ const CurrentSpotDisplay = ({ has_tick_count, spot, tick }: TCurrentSpotDisplayP
             )}
             <div className='current-spot'>
                 <Text size='xl' bold>
-                    {spot?.slice(0, -1)}
+                    {spot.slice(0, -1)}
                 </Text>
                 <div className='current-spot__last-digit-container'>
                     <div

--- a/packages/trader/src/AppV2/Components/CurrentSpot/current-spot-display.tsx
+++ b/packages/trader/src/AppV2/Components/CurrentSpot/current-spot-display.tsx
@@ -69,7 +69,7 @@ const CurrentSpotDisplay = ({ has_tick_count, spot, tick }: TCurrentSpotDisplayP
             setShouldEnterFromTop(false);
             setShouldEnterFromBottom(false);
             setDisplayedLastDigit(last_digit_ref.current % 10);
-        }, 240);
+        }, 240); // equal to total animation time
 
         const getAction = () => {
             let action: string = ACTIONS.ADD10;

--- a/packages/trader/src/AppV2/Components/CurrentSpot/current-spot.scss
+++ b/packages/trader/src/AppV2/Components/CurrentSpot/current-spot.scss
@@ -99,7 +99,7 @@
             @keyframes enter-from-left {
                 from {
                     transform: translateX(50%);
-                    margin-right: 50%;
+                    margin-inline-end: 50%;
                 }
             }
         }

--- a/packages/trader/src/AppV2/Components/CurrentSpot/current-spot.tsx
+++ b/packages/trader/src/AppV2/Components/CurrentSpot/current-spot.tsx
@@ -28,8 +28,8 @@ const CurrentSpot = observer(() => {
         is_ended,
     } = last_contract.contract_info?.entry_tick || !prev_contract ? last_contract : prev_contract;
     const { digit_tick, symbol, setDigitTick } = useTraderStore();
-    const prev_contract_id = usePrevious(contract_info.contract_id);
-    const { entry_tick, date_start, contract_type, tick_stream, underlying } = contract_info;
+    const { contract_id, entry_tick, date_start, contract_type, tick_stream, underlying } = contract_info;
+    const prev_contract_id = usePrevious(contract_id);
 
     let tick = digit_tick;
 
@@ -97,8 +97,7 @@ const CurrentSpot = observer(() => {
             prev_contract?.contract_info &&
             !prev_contract?.contract_info?.is_sold &&
             last_contract.contract_info?.entry_tick;
-        const is_next_contract_opened =
-            prev_contract_id && contract_info?.contract_id && prev_contract_id !== contract_info?.contract_id;
+        const is_next_contract_opened = prev_contract_id && contract_id && prev_contract_id !== contract_id;
         if (has_multiple_contracts && is_next_contract_opened) {
             setShouldEnterFromTop(true);
             contract_switching_timer.current = setTimeout(() => {
@@ -108,7 +107,7 @@ const CurrentSpot = observer(() => {
         } else if (!should_enter_from_top) {
             setNewData();
         }
-    }, [contract_info, last_contract, prev_contract, prev_contract_id, setNewData, should_enter_from_top]);
+    }, [contract_id, last_contract, prev_contract, prev_contract_id, setNewData, should_enter_from_top]);
 
     React.useEffect(() => {
         // TODO: move this logic to Assets feature when it's available:

--- a/packages/trader/src/AppV2/Components/CurrentSpot/current-spot.tsx
+++ b/packages/trader/src/AppV2/Components/CurrentSpot/current-spot.tsx
@@ -10,16 +10,12 @@ import { TickSpotData } from '@deriv/api-types';
 import CurrentSpotDisplay from './current-spot-display';
 import { isDigitContractWinning } from 'AppV2/Utils/trade-params-utils';
 
-type TCurrentSpotProps = {
-    className?: string;
-};
-
 const STATUS = {
     LOST: 'lost',
     WON: 'won',
 };
 
-const CurrentSpot = observer(({ className }: TCurrentSpotProps) => {
+const CurrentSpot = observer(() => {
     const contract_switching_timer = React.useRef<ReturnType<typeof setTimeout>>();
 
     const { contract_trade } = useStore();
@@ -33,16 +29,15 @@ const CurrentSpot = observer(({ className }: TCurrentSpotProps) => {
     } = last_contract.contract_info?.entry_tick || !prev_contract ? last_contract : prev_contract;
     const { digit_tick, symbol, setDigitTick } = useTraderStore();
     const prev_contract_id = usePrevious(contract_info.contract_id);
+    const { entry_tick, date_start, contract_type, tick_stream, underlying } = contract_info;
 
     let tick = digit_tick;
 
     const is_contract_elapsed = isContractElapsed(contract_info, tick);
     const status = !is_contract_elapsed && !!tick ? display_status : null;
-    const { date_start, contract_type, underlying } = contract_info;
 
     // tick from contract_info.tick_stream differs from a ticks_history API tick.
     if (date_start && !is_contract_elapsed) {
-        const tick_stream = contract_info.tick_stream;
         if (tick_stream?.length) {
             const t = toJS(tick_stream.slice(-1)[0]);
             tick = {
@@ -84,7 +79,7 @@ const CurrentSpot = observer(({ className }: TCurrentSpotProps) => {
 
     const barrier = !is_contract_elapsed && !!tick ? Number(contract_info.barrier) : null;
     const is_winning = isDigitContractWinning(contract_type, barrier, latest_digit.digit);
-    const has_contract = is_digit_contract && status && latest_digit.spot && !!contract_info.entry_tick;
+    const has_contract = is_digit_contract && status && latest_digit.spot && !!entry_tick;
     const has_open_contract = has_contract && !is_ended;
     const has_relevant_tick_data = underlying === symbol || !underlying;
     const should_show_tick_count = has_contract && has_relevant_tick_data;
@@ -131,7 +126,6 @@ const CurrentSpot = observer(({ className }: TCurrentSpotProps) => {
         <div
             className={clsx(
                 'trade__current-spot',
-                className,
                 should_show_tick_count && 'trade__current-spot--has-contract',
                 should_show_tick_count && should_enter_from_left && 'trade__current-spot--enter-from-left',
                 (is_won || (has_open_contract && is_winning)) && 'trade__current-spot--won',

--- a/packages/trader/src/AppV2/Components/CurrentSpot/current-spot.tsx
+++ b/packages/trader/src/AppV2/Components/CurrentSpot/current-spot.tsx
@@ -39,13 +39,13 @@ const CurrentSpot = observer(() => {
     // tick from contract_info.tick_stream differs from a ticks_history API tick.
     if (date_start && !is_contract_elapsed) {
         if (tick_stream?.length) {
-            const t = toJS(tick_stream.slice(-1)[0]);
+            const { epoch, tick: latest_stream_tick, tick_display_value } = toJS(tick_stream.slice(-1)[0]);
             tick = {
-                ask: t.tick,
-                bid: t.tick,
-                epoch: t.epoch,
-                pip_size: t.tick_display_value?.split('.')[1].length,
-                quote: t.tick,
+                ask: latest_stream_tick,
+                bid: latest_stream_tick,
+                epoch,
+                pip_size: tick_display_value?.split('.')[1].length,
+                quote: latest_stream_tick,
                 current_tick: tick_stream.length,
             } as TickSpotData;
         }
@@ -67,9 +67,9 @@ const CurrentSpot = observer(() => {
     // latest_digit refers to digit and spot values from the latest price:
     const latest_digit = React.useMemo(
         () =>
-            !(is_won || is_lost)
-                ? { digit: latest_tick_digit, spot: latest_tick_quote_price }
-                : (last_contract_digit as { digit: number | null; spot: string | null }),
+            is_won || is_lost
+                ? (last_contract_digit as { digit: number | null; spot: string | null })
+                : { digit: latest_tick_digit, spot: latest_tick_quote_price },
         [is_won, is_lost, latest_tick_digit, latest_tick_quote_price, last_contract_digit]
     );
 

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/__tests__/allow-equals.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/__tests__/allow-equals.spec.tsx
@@ -5,7 +5,6 @@ import { mockStore } from '@deriv/stores';
 import ModulesProvider from 'Stores/Providers/modules-providers';
 import { hasCallPutEqual, hasDurationForCallPutEqual } from 'Stores/Modules/Trading/Helpers/allow-equals';
 import TraderProviders from '../../../../../trader-providers';
-import { ReportsStoreProvider } from '../../../../../../../reports/src/Stores/useReportsStores';
 import AllowEquals from '../allow-equals';
 
 jest.mock('Stores/Modules/Trading/Helpers/allow-equals', () => ({

--- a/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/__tests__/allow-equals.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/AllowEquals/__tests__/allow-equals.spec.tsx
@@ -33,11 +33,9 @@ describe('AllowEquals', () => {
     const mockAllowEquals = () => {
         return (
             <TraderProviders store={default_mock_store}>
-                <ReportsStoreProvider>
-                    <ModulesProvider store={default_mock_store}>
-                        <AllowEquals is_minimized />
-                    </ModulesProvider>
-                </ReportsStoreProvider>
+                <ModulesProvider store={default_mock_store}>
+                    <AllowEquals is_minimized />
+                </ModulesProvider>
             </TraderProviders>
         );
     };

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/__tests__/digit.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/__tests__/digit.spec.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Digit from '../digit';
+
+describe('Digit', () => {
+    const mock_props = {
+        digit: 5,
+        digit_stats: [120, 86, 105, 94, 85, 86, 124, 107, 90, 103],
+        is_active: false,
+        is_disabled: false,
+        is_max: false,
+        is_min: false,
+        onClick: jest.fn(),
+    };
+    const percentage_testid = 'dt_digit_stats_percentage';
+
+    it('should not render digit if digit is passed as undefined despite the type restriction', () => {
+        const { container } = render(<Digit {...mock_props} digit={undefined as unknown as number} />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+    it('should render an enabled digit button with stats if digit and digit_stats are defined', () => {
+        render(<Digit {...mock_props} />);
+
+        expect(screen.getByRole('button', { name: '5' })).toBeEnabled();
+        expect(screen.getByText('8.6%')).toBeInTheDocument();
+    });
+    it('should render digit button without stats is digit_stats for the digit is not available', () => {
+        render(<Digit {...mock_props} digit_stats={[]} />);
+
+        expect(screen.getByRole('button', { name: '5' })).toBeEnabled();
+        expect(screen.queryByText(/%/)).not.toBeInTheDocument();
+    });
+    it('should render a disabled digit button if is_disabled={true}', () => {
+        render(<Digit {...mock_props} is_disabled />);
+
+        expect(screen.getByRole('button', { name: '5' })).toBeDisabled();
+    });
+    it('should render a digit button with correct classname if is_active={true}', () => {
+        render(<Digit {...mock_props} is_active />);
+
+        expect(screen.getByRole('button', { name: '5' })).toHaveClass('active');
+    });
+    it('should render percentage with correct classname if is_min={true}', () => {
+        render(<Digit {...mock_props} is_min />);
+
+        expect(screen.getByTestId(percentage_testid)).toHaveClass('percentage--min');
+    });
+    it('should render percentage with correct classname if is_max={true}', () => {
+        render(<Digit {...mock_props} is_max />);
+
+        expect(screen.getByTestId(percentage_testid)).toHaveClass('percentage--max');
+    });
+});

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/__tests__/last-digit-prediction.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/__tests__/last-digit-prediction.spec.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mockStore } from '@deriv/stores';
+import TraderProviders from '../../../../../trader-providers';
+import ModulesProvider from 'Stores/Providers/modules-providers';
+import LastDigitPrediction from '../last-digit-prediction';
+
+const title = 'Last digit prediction';
+const mediaQueryList = {
+    matches: true,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+};
+
+window.matchMedia = jest.fn().mockImplementation(() => mediaQueryList);
+
+describe('LastDigitPrediction', () => {
+    let default_mock_store: ReturnType<typeof mockStore>;
+    const digit_stats = [120, 86, 105, 94, 85, 86, 124, 107, 90, 103];
+
+    beforeEach(() => {
+        default_mock_store = mockStore({
+            modules: {
+                trade: {
+                    digit_stats: [],
+                    last_digit: 5,
+                    onChange: jest.fn(),
+                },
+            },
+        });
+    });
+
+    const mockLastDigitPrediction = (props?: React.ComponentProps<typeof LastDigitPrediction>) => {
+        return (
+            <TraderProviders store={default_mock_store}>
+                <ModulesProvider store={default_mock_store}>
+                    <LastDigitPrediction {...props} />
+                </ModulesProvider>
+            </TraderProviders>
+        );
+    };
+
+    it('should render skeleton loader if is_minimized={false} and digit_stats is empty', () => {
+        render(mockLastDigitPrediction());
+
+        expect(screen.getByTestId('dt_skeleton')).toBeInTheDocument();
+    });
+    it('should render 10 enabled buttons for each digit if digit_stats are available', () => {
+        default_mock_store.modules.trade.digit_stats = digit_stats;
+        render(mockLastDigitPrediction());
+
+        const buttons = screen.getAllByRole('button');
+        expect(buttons).toHaveLength(10);
+        buttons.forEach((button: HTMLButtonElement) => {
+            expect(button).toBeEnabled();
+        });
+    });
+    it('should render 10 disabled buttons for each digit in stats mode if digit_stats are available', () => {
+        default_mock_store.modules.trade.digit_stats = digit_stats;
+        render(mockLastDigitPrediction({ is_stats_mode: true }));
+
+        const buttons = screen.getAllByRole('button');
+        expect(buttons).toHaveLength(10);
+        buttons.forEach((button: HTMLButtonElement) => {
+            expect(button).toBeDisabled();
+        });
+    });
+    it('should render component with correct last digit value when minimized', () => {
+        render(mockLastDigitPrediction({ is_minimized: true }));
+
+        expect(screen.getByText(title)).toBeInTheDocument();
+        expect(screen.getByRole('textbox')).toHaveValue(default_mock_store.modules.trade.last_digit.toString());
+    });
+    it('should show ActionSheet if user clicks on the minimized Last digit prediction param', () => {
+        render(mockLastDigitPrediction({ is_minimized: true }));
+
+        userEvent.click(screen.getByRole('textbox'));
+
+        expect(screen.getByRole('dialog')).toHaveAttribute('data-state', 'open');
+    });
+    it('should call onChange function if user opens ActionSheet, selects another digit and clicks on "Save" button', () => {
+        render(mockLastDigitPrediction({ is_minimized: true }));
+
+        userEvent.click(screen.getByRole('textbox'));
+
+        const digit_button_seven = screen.getByRole('button', { name: '7' });
+        const save_button = screen.getByRole('button', { name: 'Save' });
+
+        userEvent.click(digit_button_seven);
+        userEvent.click(save_button);
+        expect(default_mock_store.modules.trade.onChange).toBeCalled();
+    });
+});

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/__tests__/last-digit-prediction.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/__tests__/last-digit-prediction.spec.tsx
@@ -52,7 +52,7 @@ describe('LastDigitPrediction', () => {
 
         const buttons = screen.getAllByRole('button');
         expect(buttons).toHaveLength(10);
-        buttons.forEach((button: HTMLButtonElement) => {
+        buttons.forEach((button: HTMLElement) => {
             expect(button).toBeEnabled();
         });
     });
@@ -62,7 +62,7 @@ describe('LastDigitPrediction', () => {
 
         const buttons = screen.getAllByRole('button');
         expect(buttons).toHaveLength(10);
-        buttons.forEach((button: HTMLButtonElement) => {
+        buttons.forEach((button: HTMLElement) => {
             expect(button).toBeDisabled();
         });
     });

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/__tests__/last-digit-selector.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/__tests__/last-digit-selector.spec.tsx
@@ -21,7 +21,6 @@ describe('LastDigitSelector', () => {
     it('should render 10 digits for each digit if digits are available', () => {
         render(<LastDigitSelector {...mock_props} digits={digits} />);
 
-        const displayed_digits = screen.getAllByText(mocked_digit);
-        expect(displayed_digits).toHaveLength(10);
+        expect(screen.getAllByText(mocked_digit)).toHaveLength(10);
     });
 });

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/__tests__/last-digit-selector.spec.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/__tests__/last-digit-selector.spec.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import LastDigitSelector from '../last-digit-selector';
+
+const mocked_digit = 'Digit';
+
+jest.mock('../digit', () => jest.fn(() => <div>{mocked_digit}</div>));
+
+describe('LastDigitSelector', () => {
+    const digits = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    const mock_props = {
+        digits: [],
+        digit_stats: [120, 86, 105, 94, 85, 86, 124, 107, 90, 103],
+    };
+
+    it('should not render digits if digits is empty', () => {
+        render(<LastDigitSelector {...mock_props} />);
+
+        expect(screen.queryByText(mocked_digit)).not.toBeInTheDocument();
+    });
+    it('should render 10 digits for each digit if digits are available', () => {
+        render(<LastDigitSelector {...mock_props} digits={digits} />);
+
+        const displayed_digits = screen.getAllByText(mocked_digit);
+        expect(displayed_digits).toHaveLength(10);
+    });
+});

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/digit.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/digit.tsx
@@ -19,14 +19,20 @@ const Digit = ({ digit, digit_stats = [], is_active, is_disabled, is_max, is_min
 
     if (!digit && isNaN(digit)) return null;
     return (
-        <div key={digit} className={clsx('digit', is_active && 'digit--active')}>
-            <button disabled={is_disabled} onClick={() => onClick?.(digit)} name='last_digit'>
+        <div key={digit} className='digit'>
+            <button
+                className={clsx(is_active && 'active')}
+                disabled={is_disabled}
+                onClick={() => onClick?.(digit)}
+                name='last_digit'
+            >
                 <Text size='xl'>{digit}</Text>
             </button>
             {!!display_percentage && (
                 <CaptionText
                     size='sm'
                     className={clsx('percentage', is_max && 'percentage--max', is_min && 'percentage--min')}
+                    data-testid='dt_digit_stats_percentage'
                 >
                     {display_percentage}%
                 </CaptionText>

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.scss
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.scss
@@ -38,13 +38,11 @@
                 border: var(--core-borderWidth-75) solid var(--core-color-opacity-black-100);
                 background-color: var(--core-color-solid-slate-50);
             }
-            &--active {
-                button {
-                    background-color: var(--core-color-solid-slate-1400);
+            button.active {
+                background-color: var(--core-color-solid-slate-1400);
 
-                    p {
-                        color: var(--core-color-solid-slate-50);
-                    }
+                p {
+                    color: var(--core-color-solid-slate-50);
                 }
             }
             .percentage {

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-prediction.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { observer } from 'mobx-react';
 import clsx from 'clsx';
 import { ActionSheet, CaptionText, TextField } from '@deriv-com/quill-ui';
+import { Skeleton } from '@deriv/components';
 import { Localize } from '@deriv/translations';
 import { useTraderStore } from 'Stores/useTraderStores';
 import LastDigitSelector from './last-digit-selector';
@@ -15,7 +16,6 @@ const displayed_digits = [...Array(10).keys()]; // digits array [0 - 9]
 
 const LastDigitPrediction = observer(({ is_minimized, is_stats_mode }: TLastDigitSelectorProps) => {
     const { digit_stats = [], last_digit, onChange } = useTraderStore();
-
     const [is_open, setIsOpen] = React.useState(false);
     const [selected_digit, setSelectedDigit] = React.useState(last_digit);
 
@@ -69,6 +69,7 @@ const LastDigitPrediction = observer(({ is_minimized, is_stats_mode }: TLastDigi
                 </ActionSheet.Root>
             </>
         );
+    if (!digit_stats.length) return <Skeleton height={182} />;
     return (
         <div className={clsx('last-digit-prediction', is_stats_mode && 'last-digit-prediction--stats-mode')}>
             {!is_stats_mode && (

--- a/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-selector.tsx
+++ b/packages/trader/src/AppV2/Components/TradeParameters/LastDigitPrediction/last-digit-selector.tsx
@@ -5,8 +5,8 @@ type TLastDigitSelectorProps = {
     digits: number[];
     digit_stats: number[];
     is_stats_mode?: boolean;
-    onDigitSelect: (digit: number) => void;
-    selected_digit: number;
+    onDigitSelect?: (digit: number) => void;
+    selected_digit?: number;
 };
 
 const LastDigitSelector = ({

--- a/packages/trader/src/Stores/Modules/Trading/__tests__/trade-store.spec.ts
+++ b/packages/trader/src/Stores/Modules/Trading/__tests__/trade-store.spec.ts
@@ -310,4 +310,32 @@ describe('TradeStore', () => {
             await waitFor(() => expect(spyTrackEvent).not.toHaveBeenCalled());
         });
     });
+    describe('setDigitStats', () => {
+        const digit_stats = [120, 86, 105, 94, 85, 86, 124, 107, 90, 103];
+        it('should set digit_stats', () => {
+            expect(mockedTradeStore.digit_stats).toEqual([]);
+
+            mockedTradeStore.setDigitStats(digit_stats);
+
+            expect(mockedTradeStore.digit_stats).toEqual(digit_stats);
+        });
+    });
+    describe('setDigitTick', () => {
+        const tick_data = {
+            ask: 405.76,
+            bid: 405.56,
+            epoch: 1721636565,
+            id: 'f90a93f8-965a-28ab-a830-6253bff4cc98',
+            pip_size: 2,
+            quote: 405.66,
+            symbol,
+        };
+        it('should set digit_tick', () => {
+            expect(mockedTradeStore.digit_tick).toBeNull();
+
+            mockedTradeStore.setDigitTick(tick_data);
+
+            expect(mockedTradeStore.digit_tick).toEqual(tick_data);
+        });
+    });
 });


### PR DESCRIPTION
## Changes:

- to add tests for last digit selector & current spot + utils
- 
<img width="1141" alt="Screenshot 2024-07-22 at 2 26 10 PM" src="https://github.com/user-attachments/assets/01f1c379-3fe7-4af7-9dec-5b4e2e4cf678">
<img width="1152" alt="Screenshot 2024-07-22 at 3 49 19 PM" src="https://github.com/user-attachments/assets/25ec3320-9fc5-4fa3-84ec-06901f1fc60e">
<img width="794" alt="Screenshot 2024-07-22 at 6 14 51 PM" src="https://github.com/user-attachments/assets/f1a10bcb-6635-4aa4-a853-f64bd0dd0b19">

